### PR TITLE
refac: fix python-dot env warnings

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -16,7 +16,7 @@ def json_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
     A simple settings source that loads variables from a JSON file
     at the project's root.
     """
-    encoding = settings.__config__.env_file_encoding
+    encoding = "utf-8"
     env_file = "config.json"
     return json.loads(Path(env_file).read_text(encoding))
 
@@ -38,8 +38,6 @@ class Settings(BaseSettings):
     allow_origins: List[str] = ["*"]
 
     class Config:
-        env_file_encoding = "utf-8"
-
         @classmethod
         def customise_sources(
             cls,


### PR DESCRIPTION
This prevents python-dot env from trying to parse json configuration file, resulting in warnings that looks like this:

```
Python-dotenv could not parse statement starting at line 2
Python-dotenv could not parse statement starting at line 4
Python-dotenv could not parse statement starting at line 5
Python-dotenv could not parse statement starting at line 8
Python-dotenv could not parse statement starting at line 9

```