### PR TITLE
Allow time for environments to sync

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -34,10 +34,10 @@ cache_service = CacheService(settings)
 @app.get("/proxy/health")
 def health_check():
     with suppress(TypeError):
-        if (
-            datetime.now() - cache_service.last_updated_at
-        ).total_seconds() <= settings.api_poll_frequency:
-            return {"status": "ok"}
+        last_updated = datetime.now() - cache_service.last_updated_at
+        buffer = 30 * len(settings.environment_key_pairs)  # 30s per environment
+        if last_updated.total_seconds() <= settings.api_poll_frequency + buffer:
+            return JSONResponse(status_code=200, content={"status": "ok"})
 
     return JSONResponse(status_code=500, content={"status": "error"})
 


### PR DESCRIPTION
Allows an extra 30 seconds per environment to sync before assuming the data is stale and the instance unhealthy.

As designed before, the health check didn't allow any time for environments to sync before marking the instance as unhealthy. This could happen if a health check ping arrived during the environment refresh, meaning the `api_poll_frequency` had elapsed, but its refresh had not yet finished. It'd be marked as stale when it was just waiting.