### PR TITLE
Improve handling of unknown key errors

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import requests
 
+from .exceptions import FlagsmithUnknownKeyError
 from .settings import Settings
 
 logger = logging.getLogger(__name__)
@@ -39,4 +40,7 @@ class CacheService:
             self.last_updated_at = datetime.now()
 
     def get_environment(self, client_side_key):
-        return self._cache[client_side_key]
+        try:
+            return self._cache[client_side_key]
+        except KeyError:
+            raise FlagsmithUnknownKeyError(client_side_key)

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,0 +1,2 @@
+class FlagsmithUnknownKeyError(KeyError):
+    pass

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from flag_engine.identities.models import IdentityModel
 from fastapi_utils.tasks import repeat_every
 
 from .cache import CacheService
+from .exceptions import FlagsmithUnknownKeyError
 from .features import filter_out_server_key_only_feature_states
 from .mappers import (
     map_feature_state_to_response_data,
@@ -28,6 +29,17 @@ from .sse import router as sse_router
 app = FastAPI()
 settings = Settings()
 cache_service = CacheService(settings)
+
+
+@app.exception_handler(FlagsmithUnknownKeyError)
+async def unknown_key_error(request, exc):
+    return JSONResponse(
+        status_code=401,
+        content={
+            "status": "unauthorized",
+            "message": f"unknown key {exc}",
+        },
+    )
 
 
 @app.get("/health", deprecated=True)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,8 @@
+import pytest
 import requests
 
 from src.cache import CacheService
+from src.exceptions import FlagsmithUnknownKeyError
 from src.settings import Settings
 
 settings = Settings(
@@ -91,3 +93,9 @@ def test_get_environment_works_correctly(mocker):
     cache_service.get_environment(settings.environment_key_pairs[0].client_side_key)
     cache_service.get_environment(settings.environment_key_pairs[1].client_side_key)
     assert mocked_fetch_document.call_count == 2
+
+
+def test_get_environment_raises_for_unknown_keys():
+    cache_service = CacheService(settings)
+    with pytest.raises(FlagsmithUnknownKeyError):
+        cache_service.get_environment("test_env_key_unknown")


### PR DESCRIPTION
Use an internal exception type and a dedicated exception handler, ensuring unknown key errors are correctly returned as 403.