### PR TITLE
Return JSONResponse(dict) instead of dict

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -71,7 +71,7 @@ def flags(feature: str = None, x_environment_key: str = Header(None)):
         )
         data = map_feature_states_to_response_data(feature_states)
 
-    return data
+    return JSONResponse(data)
 
 
 @app.post("/api/v1/identities/")
@@ -100,7 +100,7 @@ def identity(
             identity_hash_key=identity.composite_key,
         ),
     }
-    return data
+    return JSONResponse(data)
 
 
 @app.on_event("startup")

--- a/tests/fixtures/response_data.py
+++ b/tests/fixtures/response_data.py
@@ -1,12 +1,10 @@
-from decimal import Decimal
-
 _segment_override_feature_state = {
     "multivariate_feature_state_values": [],
     "feature_state_value": "segment_override",
     "feature": {
         "name": "feature_2",
         "type": "STANDARD",
-        "id": Decimal("2"),
+        "id": 2,
     },
     "enabled": True,
 }
@@ -18,7 +16,7 @@ _environment_feature_state_1 = {
     "feature": {
         "name": "feature_1",
         "type": "STANDARD",
-        "id": Decimal("1"),
+        "id": 1,
     },
     "enabled": False,
 }
@@ -30,7 +28,7 @@ _environment_feature_state_2 = {
     "feature": {
         "name": "feature_2",
         "type": "STANDARD",
-        "id": Decimal("2"),
+        "id": 2,
     },
     "enabled": True,
 }
@@ -42,7 +40,7 @@ _environment_feature_state_3 = {
     "feature": {
         "name": "feature_3",
         "type": "STANDARD",
-        "id": Decimal("3"),
+        "id": 3,
     },
     "enabled": False,
 }
@@ -69,7 +67,7 @@ _segment_1 = {
             ],
         }
     ],
-    "id": Decimal("1"),
+    "id": 1,
     "feature_states": [_segment_override_feature_state],
 }
 
@@ -79,7 +77,7 @@ _project_1 = {
     "organisation": {
         "feature_analytics": False,
         "name": "org-1",
-        "id": Decimal("1"),
+        "id": 1,
         "persist_trait_data": True,
         "stop_serving_flags": False,
     },
@@ -98,5 +96,5 @@ environment_1 = {
     ],
     "api_key": "environment_1_api_key",
     "project": _project_1,
-    "id": Decimal("1"),
+    "id": 1,
 }


### PR DESCRIPTION
A good chunk of the compute done by the Edge Proxy is JSON marshalling and unmarshalling. When returning plain dictionaries, FastAPI inspects every individual item inside to make sure it's serializable. We know it is in this case, as if it weren't client SDKs would not work.

From the docs:

> For large responses, returning a Response directly is much faster than returning a dictionary.
>
> This is because by default, FastAPI will inspect every item inside and make sure it is serializable with JSON, using the same JSON Compatible Encoder explained in the tutorial. This is what allows you to return arbitrary objects, for example database models.
>
> But if you are certain that the content that you are returning is serializable with JSON, you can pass it directly to the response class and avoid the extra overhead that FastAPI would have by passing your return content through the jsonable_encoder before passing it to the response class.

https://fastapi.tiangolo.com/advanced/custom-response

Serving Todoist and Twist on a few ECS instances with 4 vCPUs shows:
- Reduction in average CPU usage of 5%
- Reduction in average request latency of 15%
- Increased throughput by 50% (~1850 req/m to ~2750 req/m)

The tricky part was really 98bd0bc853ecf586129698adb1ed0b34e30a3b7b, but as explained in the commit message, it appears this may be an artifact of the past since the engine no longer relies on decimals. We've been running this in production for the past couple of weeks uneventfully and to a major throughput uplift.