### PR TITLE
Adopt orjson

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,7 @@ flagsmith-flag-engine
 python-decouple
 python-dotenv
 pydantic
+orjson
 # sse-stuff
 sse-starlette
 asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,8 @@ idna==3.4
     #   requests
 marshmallow==3.20.1
     # via -r requirements.in
+orjson==3.9.7
+    # via -r requirements.in
 packaging==23.1
     # via marshmallow
 pydantic==1.10.12

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,5 @@
+import unittest.mock
+
 import pytest
 import requests
 
@@ -16,14 +18,19 @@ settings = Settings(
 
 def test_refresh_makes_correct_http_call(mocker):
     # Given
-    mocked_session = mocker.patch("src.cache.requests.Session")
+    mocked_get = mocker.patch("src.cache.requests.Session.get")
+    mocked_get.side_effect = [
+        unittest.mock.AsyncMock(text='{"key1": "value1"}'),
+        unittest.mock.AsyncMock(text='{"key2": "value2"}'),
+    ]
     mocked_datetime = mocker.patch("src.cache.datetime")
     cache_service = CacheService(settings)
 
     # When
     cache_service.refresh()
+
     # Then
-    mocked_session.return_value.get.assert_has_calls(
+    mocked_get.assert_has_calls(
         [
             mocker.call(
                 f"{settings.api_url}/environment-document/",


### PR DESCRIPTION
_#74 should be merged before this one. If it's not accepted, I should adjust this one accordingly._

---

Continuation of the performance work started in #75. A good chunk of the compute done by the Edge Proxy is JSON marshalling and unmarshalling, and having a more performant library has an impact.

Serving Todoist and Twist on a few ECS instances with 4 vCPUs shows:

- Reduction in average CPU usage of ~1%
- Reduction in p99 latency of ~5%
- Increased throughput by ~8%

With #75 and this one, an ECS instance with 4 vCPU can now handle 3000 requests per minute without noticeable variation to p99 latency.