### PR TITLE
Enable gzip-compressing middleware

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from fastapi import FastAPI, Header
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import ORJSONResponse
 from flag_engine.engine import (
     get_environment_feature_state,
@@ -133,4 +134,5 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(GZipMiddleware, minimum_size=1000)
 app.include_router(sse_router)


### PR DESCRIPTION
We've seen a 6x reduction in traffic from enabling this middleware:

![chore: enable gzip-compressing middleware by artyom · Pull Request #26 · Doistflagsmith-edge-proxy 2023-11-09 at 1 11 03 AM jpg](https://github.com/Flagsmith/edge-proxy/assets/102931/b546132d-7bd9-4b7a-97b1-a6679417d4a8)

Without any impact to CPU utilization:

![chore enable gzip-compressing middleware by artyom · Pull Request #26 · Doistflagsmith-edge-proxy 2023-11-09 at 1 11 57 AM](https://github.com/Flagsmith/edge-proxy/assets/102931/627a73f1-63ac-490c-a7ce-a69d5a0251fb)

Straight out of the [documentation](https://fastapi.tiangolo.com/advanced/middleware/#gzipmiddleware).