### PR TITLE
fix: `Too much data for declared Content-Length` error when endpoint caches enabled

### DIFF
--- a/src/environments.py
+++ b/src/environments.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from functools import lru_cache
 
 import httpx
-from fastapi.responses import ORJSONResponse
 from flag_engine.engine import (
     get_environment_feature_state,
     get_environment_feature_states,
@@ -15,7 +14,7 @@ from flag_engine.identities.models import IdentityModel
 from orjson import orjson
 
 from src.cache import BaseEnvironmentsCache, LocalMemEnvironmentsCache
-from src.exceptions import FlagsmithUnknownKeyError, FeatureNotFoundError
+from src.exceptions import FeatureNotFoundError, FlagsmithUnknownKeyError
 from src.feature_utils import filter_out_server_key_only_feature_states
 from src.mappers import (
     map_feature_state_to_response_data,

--- a/src/environments.py
+++ b/src/environments.py
@@ -15,7 +15,7 @@ from flag_engine.identities.models import IdentityModel
 from orjson import orjson
 
 from src.cache import BaseEnvironmentsCache, LocalMemEnvironmentsCache
-from src.exceptions import FlagsmithUnknownKeyError
+from src.exceptions import FlagsmithUnknownKeyError, FeatureNotFoundError
 from src.feature_utils import filter_out_server_key_only_feature_states
 from src.mappers import (
     map_feature_state_to_response_data,
@@ -73,7 +73,7 @@ class EnvironmentService:
 
     def get_flags_response_data(
         self, environment_key: str, feature: str = None
-    ) -> ORJSONResponse:
+    ) -> dict[str, typing.Any]:
         environment_document = self.get_environment(environment_key)
         environment = build_environment_model(environment_document)
 
@@ -84,13 +84,7 @@ class EnvironmentService:
                 feature_states=[feature_state],
                 environment=environment,
             ):
-                return ORJSONResponse(
-                    status_code=404,
-                    content={
-                        "status": "not_found",
-                        "message": f"feature '{feature}' not found",
-                    },
-                )
+                raise FeatureNotFoundError()
 
             data = map_feature_state_to_response_data(feature_state)
 
@@ -101,11 +95,11 @@ class EnvironmentService:
             )
             data = map_feature_states_to_response_data(feature_states)
 
-        return ORJSONResponse(data)
+        return data
 
     def get_identity_response_data(
         self, input_data: IdentityWithTraits, environment_key: str
-    ) -> ORJSONResponse:
+    ) -> dict[str, typing.Any]:
         environment_document = self.get_environment(environment_key)
         environment = build_environment_model(environment_document)
         identity = IdentityModel(
@@ -127,7 +121,7 @@ class EnvironmentService:
                 identity_hash_key=identity.composite_key,
             ),
         }
-        return ORJSONResponse(data)
+        return data
 
     def get_environment(self, client_side_key: str) -> dict[str, typing.Any]:
         if environment_document := self.cache.get_environment(client_side_key):

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,2 +1,6 @@
 class FlagsmithUnknownKeyError(KeyError):
     pass
+
+
+class FeatureNotFoundError(Exception):
+    pass

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from fastapi_utils.tasks import repeat_every
 
 from .cache import LocalMemEnvironmentsCache
 from .environments import EnvironmentService
-from .exceptions import FlagsmithUnknownKeyError, FeatureNotFoundError
+from .exceptions import FeatureNotFoundError, FlagsmithUnknownKeyError
 from .models import IdentityWithTraits
 from .settings import Settings
 
@@ -60,7 +60,7 @@ async def flags(feature: str = None, x_environment_key: str = Header(None)):
                 "message": f"feature '{feature}' not found",
             },
         )
-    
+
     return ORJSONResponse(data)
 
 


### PR DESCRIPTION
When using endpoint caches, for large payload sizes, the Edge Proxy would throw an exception but return a 200 OK response with an empty body. Looking in the logs, I determined the cause was 

```
h11._util.LocalProtocolError: Too much data for declared Content-Length
```

When I compared a cached response with a non-cached response, I could see that the cached response was setting a `Content-Length` header about 1/4 of the size of the non-cached response. 

I haven't investigated the cause of this too deeply as it seems to be buried deep in the internals of `lru_cache` and/or `ORJSONResponse` code. Instead, I have abstracted the serialization back to the `main` module and out of the environment service which, to me, feels cleaner anyway. It adds a small amount of processing back to the response generation, even when a cache hit is made, but in testing this seems negligible. 

To test this fix, I attempted to write a test using the Fast API client, but I wasn't able to reproduce the error. Instead, I ran the edge proxy locally with the endpoint caches enabled and verified that multiple requests to the same endpoint, with the same data, work as expected. 