### PR TITLE
feat: allow config file to be defined via environment variable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,52 @@
 
 https://docs.flagsmith.com/advanced-use/edge-proxy
 
+## Local development
+
+### Prerequisites
+
+- `Python3`
+- `Docker`
+
+### Setup local environment and pre-commit hooks
+
+1. Setup virtual environment (Optional, but recommended)
+```shell
+# Create a virtual environment (first time)
+python3 -m venv venv
+# Activate the virtual environment
+source ./venv/bin/activate
+
+# Deactivate virtual environment when done
+deactivate
+```
+2. Install dependencies
+```shell
+# Install python requirements
+pip install -r requirements.txt -r requirements-dev.txt
+```
+3. Install pre-commit hooks
+```shell
+# Confirm pre-commit is installed
+pre-commit --version
+
+# Install pre-commit hooks
+pre-commit install
+```
+
+### Build and run Docker image locally
+
+```shell
+# Build image
+docker build . -t edge-proxy-local
+
+# Run image 
+docker run -it --rm \
+  -v <path-to-config>/config.json:/app/config.json \
+  -p 8000:8000 \
+  edge-proxy-local:latest
+```
+
 ## Configuration
 
 Edge proxy can be configured using the `config.json` file located at the root or at a location defined by the `CONFIG_PATH` environment variable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ https://docs.flagsmith.com/advanced-use/edge-proxy
 
 ## Configuration
 
-Edge proxy can be configured using the `config.json` file located at the root.
+Edge proxy can be configured using the `config.json` file located at the root or at a location defined by the `CONFIG_PATH` environment variable.
 
 ### Supported configuration
 
@@ -22,6 +22,8 @@ of edge-proxy
 
 ### Here are some examples of adding local `config.json` to edge-proxy:
 
+#### Default location
+
 - With docker run:
   `docker run -v /<path-to-local>/config.json:/app/config.json flagsmith/edge-proxy:latest`
 
@@ -36,6 +38,26 @@ services:
       - type: bind
         source: /<path-to-local>/config.json
         target: /app/config.json
+```
+
+#### Location defined by environment variable
+
+- With docker run:
+  `docker run -e CONFIG_PATH='/tmp/config.json' -v /<path-to-local>/config.json:/tmp/config.json flagsmith/edge-proxy:latest`
+
+- With docker compose:
+
+```yaml
+version: "3.9"
+services:
+  edge_proxy:
+    image: flagsmith/edge-proxy:latest
+    volumes:
+      - type: bind
+        source: /<path-to-local>/config.json
+        target: /tmp/config.json
+    environment:
+      - CONFIG_PATH='/tmp/config.json'
 ```
 
 ## Load Testing

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
@@ -31,7 +32,7 @@ def json_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
     at the project's root.
     """
     encoding = "utf-8"
-    env_file = "config.json"
+    env_file = os.environ.get('CONFIG_PATH', 'config.json')
     return json.loads(Path(env_file).read_text(encoding))
 
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -32,7 +32,7 @@ def json_config_settings_source(settings: BaseSettings) -> Dict[str, Any]:
     at the project's root.
     """
     encoding = "utf-8"
-    env_file = os.environ.get('CONFIG_PATH', 'config.json')
+    env_file = os.environ.get("CONFIG_PATH", "config.json")
     return json.loads(Path(env_file).read_text(encoding))
 
 


### PR DESCRIPTION
## Description

- add config file location fetching from environment variable (`CONFIG_PATH`). Defaulting to `config.json` (previous value) if environment variable is not defined.
- preserves backwards compatibility by not requiring `CONFIG_PATH` to be defined