### PR TITLE
feat: make health check configurable

### DIFF
--- a/src/edge_proxy/health_check/responses.py
+++ b/src/edge_proxy/health_check/responses.py
@@ -1,0 +1,25 @@
+import typing
+from datetime import datetime
+from typing import Optional
+
+from fastapi.responses import ORJSONResponse
+from starlette.background import BackgroundTask
+
+
+class HealthCheckResponse(ORJSONResponse):
+    def __init__(
+        self,
+        status_code: int = 200,
+        status: str = "ok",
+        reason: Optional[str] = None,
+        last_successful_update: Optional[datetime] = None,
+        headers: typing.Mapping[str, str] | None = None,
+        media_type: str | None = None,
+        background: BackgroundTask | None = None,
+    ):
+        content = {
+            "status": status,
+            "reason": reason,
+            "last_successful_update": last_successful_update,
+        }
+        super().__init__(status_code=status_code, content=content, headers=headers, media_type=media_type, background=background)

--- a/src/edge_proxy/server.py
+++ b/src/edge_proxy/server.py
@@ -51,7 +51,7 @@ async def health_check():
         )
 
     if settings.health_check.count_stale_documents_as_failing:
-        buffer = (settings.health_check.grace_period_seconds or 30) * len(
+        buffer = settings.health_check.grace_period_seconds * len(
             settings.environment_key_pairs
         )
         threshold = datetime.now() - timedelta(seconds=buffer)

--- a/src/edge_proxy/server.py
+++ b/src/edge_proxy/server.py
@@ -54,7 +54,9 @@ async def health_check():
         buffer = settings.health_check.grace_period_seconds * len(
             settings.environment_key_pairs
         )
-        threshold = datetime.now() - timedelta(seconds=buffer)
+        threshold = datetime.now() - timedelta(
+            seconds=settings.api_poll_frequency_seconds + buffer
+        )
         if last_updated_at < threshold:
             return HealthCheckResponse(
                 status_code=500,

--- a/src/edge_proxy/settings.py
+++ b/src/edge_proxy/settings.py
@@ -4,7 +4,7 @@ import os
 import sys
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import structlog
 
@@ -100,6 +100,11 @@ class ServerSettings(BaseModel):
     reload: bool = False
 
 
+class HealthCheckSettings(BaseModel):
+    count_stale_documents_as_failing: bool = True
+    grace_period_seconds: Optional[int] = None
+
+
 class AppSettings(BaseModel):
     environment_key_pairs: list[EnvironmentKeyPair] = Field(
         default_factory=lambda: [
@@ -128,6 +133,7 @@ class AppSettings(BaseModel):
     allow_origins: list[str] = Field(default_factory=lambda: ["*"])
     logging: LoggingSettings = LoggingSettings()
     server: ServerSettings = ServerSettings()
+    health_check: HealthCheckSettings = HealthCheckSettings()
 
 
 class AppConfig(AppSettings, BaseSettings):

--- a/src/edge_proxy/settings.py
+++ b/src/edge_proxy/settings.py
@@ -4,7 +4,7 @@ import os
 import sys
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import structlog
 
@@ -102,7 +102,7 @@ class ServerSettings(BaseModel):
 
 class HealthCheckSettings(BaseModel):
     count_stale_documents_as_failing: bool = True
-    grace_period_seconds: Optional[int] = None
+    grace_period_seconds: int = 30
 
 
 class AppSettings(BaseModel):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 
+from edge_proxy.settings import AppSettings, HealthCheckSettings
 from tests.fixtures.response_data import environment_1
 
 if typing.TYPE_CHECKING:
@@ -30,18 +31,53 @@ def test_health_check_returns_500_if_cache_was_not_updated(
 ) -> None:
     response = client.get("/proxy/health")
     assert response.status_code == 500
-    assert response.json() == {"status": "error"}
+    assert response.json() == {
+        "status": "error",
+        "reason": "environment document(s) not updated.",
+        "last_successful_update": None,
+    }
 
 
 def test_health_check_returns_500_if_cache_is_stale(
     mocker: MockerFixture,
     client: TestClient,
 ) -> None:
+    last_updated_at = datetime.now() - timedelta(days=10)
     mocked_environment_service = mocker.patch("edge_proxy.server.environment_service")
-    mocked_environment_service.last_updated_at = datetime.now() - timedelta(days=10)
+    mocked_environment_service.last_updated_at = last_updated_at
     response = client.get("/proxy/health")
     assert response.status_code == 500
-    assert response.json() == {"status": "error"}
+    assert response.json() == {
+        "status": "error",
+        "reason": "environment document(s) stale.",
+        "last_successful_update": last_updated_at.isoformat(),
+    }
+
+
+def test_health_check_returns_200_if_cache_is_stale_and_health_check_configured_correctly(
+    mocker: MockerFixture,
+    client: TestClient,
+) -> None:
+    # Given
+    settings = AppSettings(
+        health_check=HealthCheckSettings(count_stale_documents_as_failing=False)
+    )
+    mocker.patch("edge_proxy.server.settings", settings)
+
+    last_updated_at = datetime.now() - timedelta(days=10)
+    mocked_environment_service = mocker.patch("edge_proxy.server.environment_service")
+    mocked_environment_service.last_updated_at = last_updated_at
+
+    # When
+    response = client.get("/proxy/health")
+
+    # Then
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "reason": None,
+        "last_successful_update": last_updated_at.isoformat(),
+    }
 
 
 def test_get_flags(


### PR DESCRIPTION
This PR looks to solve #120. 

It does so by making certain aspects of the health check configurable, with the bear minimum health check being to confirm that the environment document has been updated at some point. 