### PR TITLE
feat: remove unnecessary setting `health_check.count_stale_documents_as_failing`

### DIFF
--- a/src/edge_proxy/server.py
+++ b/src/edge_proxy/server.py
@@ -50,9 +50,8 @@ async def health_check():
             last_successful_update=None,
         )
 
-    if (
-        grace_period := settings.health_check.environment_update_grace_period_seconds
-    ) is not None:
+    grace_period = settings.health_check.environment_update_grace_period_seconds
+    if grace_period is not None:
         buffer = grace_period * len(settings.environment_key_pairs)
         threshold = datetime.now() - timedelta(
             seconds=settings.api_poll_frequency_seconds + buffer

--- a/src/edge_proxy/server.py
+++ b/src/edge_proxy/server.py
@@ -50,10 +50,10 @@ async def health_check():
             last_successful_update=None,
         )
 
-    if settings.health_check.count_stale_documents_as_failing:
-        buffer = settings.health_check.grace_period_seconds * len(
-            settings.environment_key_pairs
-        )
+    if (
+        grace_period := settings.health_check.environment_update_grace_period_seconds
+    ) is not None:
+        buffer = grace_period * len(settings.environment_key_pairs)
         threshold = datetime.now() - timedelta(
             seconds=settings.api_poll_frequency_seconds + buffer
         )

--- a/src/edge_proxy/settings.py
+++ b/src/edge_proxy/settings.py
@@ -4,7 +4,7 @@ import os
 import sys
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import structlog
 
@@ -101,8 +101,7 @@ class ServerSettings(BaseModel):
 
 
 class HealthCheckSettings(BaseModel):
-    count_stale_documents_as_failing: bool = True
-    grace_period_seconds: int = 30
+    environment_update_grace_period_seconds: Optional[int] = 30
 
 
 class AppSettings(BaseModel):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -60,7 +60,7 @@ def test_health_check_returns_200_if_cache_is_stale_and_health_check_configured_
 ) -> None:
     # Given
     settings = AppSettings(
-        health_check=HealthCheckSettings(count_stale_documents_as_failing=False)
+        health_check=HealthCheckSettings(environment_update_grace_period_seconds=None)
     )
     mocker.patch("edge_proxy.server.settings", settings)
 


### PR DESCRIPTION
Based on a conversation with @rolodato on https://github.com/Flagsmith/flagsmith/pull/4580, I have updated the settings added in #122 to remove the boolean setting used to configure the essentially 'infinite grace period' and replaced it with the option to set the grace period to null. In order to help with the readability though, I have also renamed the grace period field. 

Note: since the documentation has not been released for the original settings, I plan to release this as a minor update with a mention in the notes about the breaking settings changes. 