### PR TITLE
ci: use new org-level dockerhub token

### DIFF
--- a/.github/workflows/docker-publish-image.yml
+++ b/.github/workflows/docker-publish-image.yml
@@ -38,7 +38,7 @@ jobs:
             - name: Login to DockerHub
               uses: docker/login-action@v3
               with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME_WRITE }}
+                  username: ${{ vars.DOCKERHUB_USERNAME_WRITE }}
                   password: ${{ secrets.DOCKERHUB_TOKEN_WRITE }}
 
             - name: Build and push

--- a/.github/workflows/docker-publish-image.yml
+++ b/.github/workflows/docker-publish-image.yml
@@ -38,8 +38,8 @@ jobs:
             - name: Login to DockerHub
               uses: docker/login-action@v3
               with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+                  username: ${{ secrets.DOCKERHUB_USERNAME_WRITE }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN_WRITE }}
 
             - name: Build and push
               id: docker_build


### PR DESCRIPTION
Updates the docker workflow to use the new org-level variable / secret. 

The new org level variable / secret use a PAT from the `flagsmithdocker` user in our dockerhub account. 