### PR TITLE
feat: Use proxy for contacting Flagsmith

### DIFF
--- a/src/edge_proxy/environments.py
+++ b/src/edge_proxy/environments.py
@@ -40,6 +40,7 @@ class EnvironmentService:
         self.settings = settings or AppSettings()
         self._client = client or httpx.AsyncClient(
             timeout=settings.api_poll_timeout_seconds,
+            proxy=settings.proxy
         )
         self.last_updated_at = None
 

--- a/src/edge_proxy/environments.py
+++ b/src/edge_proxy/environments.py
@@ -39,8 +39,7 @@ class EnvironmentService:
         self.cache = cache or LocalMemEnvironmentsCache()
         self.settings = settings or AppSettings()
         self._client = client or httpx.AsyncClient(
-            timeout=settings.api_poll_timeout_seconds,
-            proxy=settings.proxy
+            timeout=settings.api_poll_timeout_seconds, proxy=settings.proxy
         )
         self.last_updated_at = None
 

--- a/src/edge_proxy/server.py
+++ b/src/edge_proxy/server.py
@@ -21,7 +21,10 @@ settings = get_settings()
 setup_logging(settings.logging)
 environment_service = EnvironmentService(
     LocalMemEnvironmentsCache(),
-    httpx.AsyncClient(timeout=settings.api_poll_timeout_seconds),
+    httpx.AsyncClient(
+        timeout=settings.api_poll_timeout_seconds,
+        proxy=settings.proxy
+        ),
     settings,
 )
 app = FastAPI()

--- a/src/edge_proxy/server.py
+++ b/src/edge_proxy/server.py
@@ -21,10 +21,7 @@ settings = get_settings()
 setup_logging(settings.logging)
 environment_service = EnvironmentService(
     LocalMemEnvironmentsCache(),
-    httpx.AsyncClient(
-        timeout=settings.api_poll_timeout_seconds,
-        proxy=settings.proxy
-        ),
+    httpx.AsyncClient(timeout=settings.api_poll_timeout_seconds, proxy=settings.proxy),
     settings,
 )
 app = FastAPI()

--- a/src/edge_proxy/settings.py
+++ b/src/edge_proxy/settings.py
@@ -133,7 +133,7 @@ class AppSettings(BaseModel):
     logging: LoggingSettings = LoggingSettings()
     server: ServerSettings = ServerSettings()
     health_check: HealthCheckSettings = HealthCheckSettings()
-    proxy: Optional[str] = None
+    request_client_proxy: str | None = None
 
 
 class AppConfig(AppSettings, BaseSettings):

--- a/src/edge_proxy/settings.py
+++ b/src/edge_proxy/settings.py
@@ -133,6 +133,7 @@ class AppSettings(BaseModel):
     logging: LoggingSettings = LoggingSettings()
     server: ServerSettings = ServerSettings()
     health_check: HealthCheckSettings = HealthCheckSettings()
+    proxy: Optional[str] = None
 
 
 class AppConfig(AppSettings, BaseSettings):


### PR DESCRIPTION
This pull request includes changes to the `src/edge_proxy` module to add a proxy configuration for HTTP clients. The most important changes include modifying the `AppSettings` class to include a proxy setting and updating the HTTP client initialization to use this proxy setting.

### Proxy Configuration Addition:

* [`src/edge_proxy/settings.py`](diffhunk://#diff-4573c040951bc5c2676139dcf260c4a96b0f9b830f15227322c0a1f8545da004R136): Added an optional `proxy` attribute to the `AppSettings` class.

### HTTP Client Initialization:

* [`src/edge_proxy/environments.py`](diffhunk://#diff-3d7dc215aae5142bc62d5e35b6b552f9066b63e1aabf7d63742255335767afc1L42-R42): Updated the `httpx.AsyncClient` initialization to include the `proxy` setting.
* [`src/edge_proxy/server.py`](diffhunk://#diff-cdb88993a54d443695f23679d7001540eaacaa5934cb191cf0a2274dd308497cL24-R24): Modified the `httpx.AsyncClient` initialization to use the `proxy` setting from `AppSettings`.