### PR TITLE
feat: Add GET /api/v1/identities endpoint

### DIFF
--- a/src/edge_proxy/server.py
+++ b/src/edge_proxy/server.py
@@ -91,6 +91,14 @@ async def identity(
     data = environment_service.get_identity_response_data(input_data, x_environment_key)
     return ORJSONResponse(data)
 
+@app.get("/api/v1/identities/", response_class=ORJSONResponse)
+async def get_identities(
+    identifier: str,
+    x_environment_key: str = Header(None),
+):
+    data = environment_service.get_identity_response_data(IdentityWithTraits(identifier=identifier), x_environment_key)
+    return ORJSONResponse(data)
+
 
 @app.on_event("startup")
 @repeat_every(

--- a/src/edge_proxy/server.py
+++ b/src/edge_proxy/server.py
@@ -96,7 +96,7 @@ async def identity(
 async def get_identities(
     identifier: str,
     x_environment_key: str = Header(None),
-):
+) -> ORJSONResponse:
     data = environment_service.get_identity_response_data(
         IdentityWithTraits(identifier=identifier), x_environment_key
     )

--- a/src/edge_proxy/server.py
+++ b/src/edge_proxy/server.py
@@ -91,12 +91,15 @@ async def identity(
     data = environment_service.get_identity_response_data(input_data, x_environment_key)
     return ORJSONResponse(data)
 
+
 @app.get("/api/v1/identities/", response_class=ORJSONResponse)
 async def get_identities(
     identifier: str,
     x_environment_key: str = Header(None),
 ):
-    data = environment_service.get_identity_response_data(IdentityWithTraits(identifier=identifier), x_environment_key)
+    data = environment_service.get_identity_response_data(
+        IdentityWithTraits(identifier=identifier), x_environment_key
+    )
     return ORJSONResponse(data)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -259,3 +259,27 @@ def test_post_identity__invalid_trait_data__expected_response(
         "constrained-str",
     ]
     assert response.json()["detail"][-1]["type"] == "string_too_long"
+
+
+def test_get_identities(mocker: MockerFixture, client: TestClient):
+    x_environment_key = "test_environment_key"
+    identifier = "test_identifier"
+
+    mocked_environment_cache = mocker.patch(
+        "edge_proxy.server.environment_service.cache"
+    )
+    mocked_environment_cache.get_environment.return_value = environment_1
+    mocked_environment_cache.get_identity.return_value = {
+        "environment_api_key": x_environment_key,
+        "identifier": identifier,
+    }
+
+    response = client.get(
+        "/api/v1/identities/",
+        headers={"x-environment-key": x_environment_key},
+        params={"identifier": identifier}
+    )
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["traits"] == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -261,7 +261,10 @@ def test_post_identity__invalid_trait_data__expected_response(
     assert response.json()["detail"][-1]["type"] == "string_too_long"
 
 
-def test_get_identities(mocker: MockerFixture, client: TestClient):
+def test_get_identities(
+    mocker: MockerFixture,
+    client: TestClient,
+) -> None:
     x_environment_key = "test_environment_key"
     identifier = "test_identifier"
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -277,7 +277,7 @@ def test_get_identities(mocker: MockerFixture, client: TestClient):
     response = client.get(
         "/api/v1/identities/",
         headers={"x-environment-key": x_environment_key},
-        params={"identifier": identifier}
+        params={"identifier": identifier},
     )
     data = response.json()
 


### PR DESCRIPTION
This adds the `GET /api/v1/identities` endpoint, which accepts only an identifier via query parameters and no traits. It is used by some SDKs ([example: JS](https://github.com/Flagsmith/flagsmith-js-client/blob/5cd31ca06b1dac52932a2d4e81dc889d5eb6ebf2/flagsmith-core.ts#L206)) when traits are not being used.