### PR TITLE
fix: ignore unknown env vars

### DIFF
--- a/src/edge_proxy/settings.py
+++ b/src/edge_proxy/settings.py
@@ -136,6 +136,9 @@ class AppSettings(BaseModel):
 
 
 class AppConfig(AppSettings, BaseSettings):
+    class Config:
+        extra = "ignore"
+
     @classmethod
     def settings_customise_sources(
         cls,


### PR DESCRIPTION
Related to [this issue](https://github.com/Flagsmith/edge-proxy/issues/140).

The purpose is to prevent the application from hard crashing when unrecognised environment variables are provided. 