### PR TITLE
fix: Warning when running edge-proxy-render-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Create an example configuration by running the `edge-proxy-render-config` entryp
 rye run edge-proxy-render-config
 ```
 
-This will output the example configuration to stdout and write it to `./config.json`.
+This will write the default settings to `./config.json`.
 
 Here's how to mount the file into Edge Proxy's Docker container:
 

--- a/src/edge_proxy/settings.py
+++ b/src/edge_proxy/settings.py
@@ -113,7 +113,7 @@ class AppSettings(BaseModel):
             )
         ]
     )
-    api_url: HttpUrl = "https://edge.api.flagsmith.com/api/v1"
+    api_url: HttpUrl = HttpUrl("https://edge.api.flagsmith.com/api/v1")
     api_poll_frequency_seconds: int = Field(
         default=10,
         validation_alias=AliasChoices(


### PR DESCRIPTION
```
~/s/f/edge-proxy►rye run edge-proxy-render-config                 (feat/get-identities-endpoint) 13:20
/Users/rolodato/source/flagsmith/edge-proxy/.venv/lib/python3.12/site-packages/pydantic/main.py:398: UserWarning: Pydantic serializer warnings:
  Expected `url` but got `str` - serialized value may not be as expected
  return self.__pydantic_serializer__.to_json(
{
    "environment_key_pairs": [
        {
            "server_side_key": "ser.environment_key",
            "client_side_key": "environment_key"
        }
    ],
    "api_url": "https://edge.api.flagsmith.com/api/v1",
    "api_poll_frequency_seconds": 10,
    "api_poll_timeout_seconds": 5,
    "allow_origins": [
        "*"
    ],
    "logging": {
        "enable_access_log": false,
        "log_format": "generic",
        "log_level": "INFO",
        "log_event_field_name": "message",
        "colours": false,
        "override": {}
    },
    "server": {
        "host": "0.0.0.0",
        "port": 8000,
        "reload": false
    },
    "health_check": {
        "environment_update_grace_period_seconds": 30
    }
}
```

The README description is technically incorrect since we only print to stdout if we actually wrote a config.json. Instead of changing the behaviour I chose to replace this with a less descriptive but more correct one.