### PR TITLE
feat: Immediately exit if configuration is missing or invalid

### DIFF
--- a/src/edge_proxy/settings.py
+++ b/src/edge_proxy/settings.py
@@ -8,16 +8,14 @@ from typing import Any, Optional
 
 import structlog
 
-from pydantic import AliasChoices, BaseModel, HttpUrl, IPvAnyAddress, Field
+from pydantic import AliasChoices, BaseModel, HttpUrl, IPvAnyAddress, Field, constr
 
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
-
 
 CONFIG_PATH = os.environ.get(
     "CONFIG_PATH",
     default="config.json",
 )
-
 
 logger = structlog.get_logger()
 
@@ -65,8 +63,8 @@ def json_config_settings_source() -> dict[str, Any]:
 
 
 class EnvironmentKeyPair(BaseModel):
-    server_side_key: str
-    client_side_key: str
+    server_side_key: constr(pattern=r"ser\.*", strip_whitespace=True)
+    client_side_key: constr(min_length=1, strip_whitespace=True)
 
 
 class EndpointCacheSettings(BaseModel):
@@ -105,14 +103,7 @@ class HealthCheckSettings(BaseModel):
 
 
 class AppSettings(BaseModel):
-    environment_key_pairs: list[EnvironmentKeyPair] = Field(
-        default_factory=lambda: [
-            EnvironmentKeyPair(
-                server_side_key="ser.environment_key",
-                client_side_key="environment_key",
-            )
-        ]
-    )
+    environment_key_pairs: list[EnvironmentKeyPair]
     api_url: HttpUrl = HttpUrl("https://edge.api.flagsmith.com/api/v1")
     api_poll_frequency_seconds: int = Field(
         default=10,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,8 +51,15 @@ def environment_1_feature_states_response_list_response_with_identity_override(
 
 
 @pytest.fixture(autouse=True)
-def skip_json_config_settings_source(mocker: MockerFixture) -> None:
-    mocker.patch("edge_proxy.settings.json_config_settings_source", dict)
+def mock_settings(mocker: MockerFixture) -> None:
+    mock_config = {
+        "environment_key_pairs": [
+            {"server_side_key": "ser.abc123", "client_side_key": "def456"}
+        ]
+    }
+    mocker.patch(
+        "edge_proxy.settings.json_config_settings_source", return_value=mock_config
+    )
 
 
 @pytest.fixture

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 
-from edge_proxy.settings import AppSettings, HealthCheckSettings
+from edge_proxy.settings import HealthCheckSettings
 from tests.fixtures.response_data import environment_1
 
 if typing.TYPE_CHECKING:
@@ -59,10 +59,8 @@ def test_health_check_returns_200_if_cache_is_stale_and_health_check_configured_
     client: TestClient,
 ) -> None:
     # Given
-    settings = AppSettings(
-        health_check=HealthCheckSettings(environment_update_grace_period_seconds=None)
-    )
-    mocker.patch("edge_proxy.server.settings", settings)
+    health_check = HealthCheckSettings(environment_update_grace_period_seconds=None)
+    mocker.patch("edge_proxy.server.settings.health_check", health_check)
 
     last_updated_at = datetime.now() - timedelta(days=10)
     mocked_environment_service = mocker.patch("edge_proxy.server.environment_service")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,8 +2,37 @@ import typing
 
 import pytest
 from pytest_mock import MockerFixture
+from pydantic import ValidationError
 
-from edge_proxy.settings import get_settings
+from edge_proxy.settings import get_settings, AppSettings
+
+
+def test_client_side_key_validation() -> None:
+    """
+    Test that client_side_key is properly validated.
+    """
+    # Valid
+    AppSettings(
+        environment_key_pairs=[
+            {"server_side_key": "ser.abc123", "client_side_key": "def456"}
+        ]
+    )
+
+    # Missing client_side_key
+    with pytest.raises(ValidationError):
+        AppSettings(
+            environment_key_pairs=[
+                {"server_side_key": "ser.abc123", "client_side_key": ""}
+            ]
+        )
+
+    # Invalid server_side_key
+    with pytest.raises(ValidationError):
+        AppSettings(
+            environment_key_pairs=[
+                {"server_side_key": "abc123", "client_side_key": "abc123"}
+            ]
+        )
 
 
 @pytest.mark.parametrize(
@@ -12,7 +41,7 @@ from edge_proxy.settings import get_settings
         (
             {
                 "environment_key_pairs": [
-                    {"server_side_key": "abc123", "client_side_key": "ser.def456"}
+                    {"server_side_key": "ser.abc123", "client_side_key": "def456"}
                 ],
                 "api_poll_frequency": 10,
                 "api_poll_timeout": 10,
@@ -23,7 +52,7 @@ from edge_proxy.settings import get_settings
         (
             {
                 "environment_key_pairs": [
-                    {"server_side_key": "abc123", "client_side_key": "ser.def456"}
+                    {"server_side_key": "ser.abc123", "client_side_key": "def456"}
                 ],
                 "api_poll_frequency_seconds": 10,
                 "api_poll_timeout_seconds": 10,


### PR DESCRIPTION
This is the behaviour when running the Edge Proxy with no configuration:

```
% docker run --rm flagsmith/edge-proxy

2025-03-14T18:43:17.793837Z [info     ] Started server process [1]     [uvicorn.error]
2025-03-14T18:43:17.793915Z [info     ] Waiting for application startup. [uvicorn.error]
2025-03-14T18:43:17.795896Z [info     ] Application startup complete.  [uvicorn.error]
2025-03-14T18:43:17.796444Z [info     ] Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit) [uvicorn.error]
2025-03-14T18:43:18.033553Z [info     ] HTTP Request: GET https://edge.api.flagsmith.com/api/v1/environment-document/ "HTTP/1.1 401 Unauthorized" [httpx]
2025-03-14T18:43:18.034012Z [error    ] error_fetching_document        [edge_proxy.environments] client_side_key=environment_key
Traceback (most recent call last):
  File "/app/src/edge_proxy/environments.py", line 61, in refresh_environment_caches
    environment_document = await self._fetch_document(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/src/edge_proxy/environments.py", line 150, in _fetch_document
    response.raise_for_status()
  File "/opt/venv/lib/python3.12/site-packages/httpx/_models.py", line 761, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '401 Unauthorized' for url 'https://edge.api.flagsmith.com/api/v1/environment-document/'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
```

On startup, we're always making an invalid request to fetch the environment document with ID `environment_key`. This is confusing and unnecessary.

Instead, we now validate environment key pairs using Pydantic so that any configuration errors immediately exit with a descriptive error. For example:

```
% rye run edge-proxy-serve                                                                            96.498s (feat/logging) 15:46
Traceback (most recent call last):
  File "/Users/rolodato/source/flagsmith/edge-proxy/.venv/bin/edge-proxy-serve", line 8, in <module>
    sys.exit(serve())
             ^^^^^^^
  File "/Users/rolodato/source/flagsmith/edge-proxy/src/edge_proxy/main.py", line 7, in serve
    settings = get_settings()
               ^^^^^^^^^^^^^^
  File "/Users/rolodato/source/flagsmith/edge-proxy/src/edge_proxy/settings.py", line 146, in get_settings
    return AppConfig()
           ^^^^^^^^^^^
  File "/Users/rolodato/source/flagsmith/edge-proxy/.venv/lib/python3.12/site-packages/pydantic_settings/main.py", line 84, in __init__
    super().__init__(
  File "/Users/rolodato/source/flagsmith/edge-proxy/.venv/lib/python3.12/site-packages/pydantic/main.py", line 176, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 2 validation errors for AppConfig
environment_key_pairs.0.server_side_key
  String should match pattern 'ser\.*' [type=string_pattern_mismatch, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.7/v/string_pattern_mismatch
environment_key_pairs.0.client_side_key
  String should have at least 1 character [type=string_too_short, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.7/v/string_too_short
```