### PR TITLE
feat: Add environment document endpoint

### DIFF
--- a/src/edge_proxy/server.py
+++ b/src/edge_proxy/server.py
@@ -103,6 +103,22 @@ async def get_identities(
     return ORJSONResponse(data)
 
 
+@app.get("/api/v1/environment-document", response_class=ORJSONResponse)
+async def environment_document(
+    x_environment_key: str = Header(None),
+) -> ORJSONResponse:
+    for key_pair in settings.environment_key_pairs:
+        print(key_pair)
+        if key_pair.server_side_key == x_environment_key:
+            environment_doc = environment_service.get_environment(
+                key_pair.client_side_key
+            )
+            print(environment_doc is None)
+            if environment_doc:
+                return ORJSONResponse(environment_doc)
+    return ORJSONResponse(status_code=401, content=None)
+
+
 @app.on_event("startup")
 @repeat_every(
     seconds=settings.api_poll_frequency_seconds,


### PR DESCRIPTION
Adds a `GET /environment-document` endpoint for use by server-side SDKs in local evaluation mode.

Using the Edge Proxy this way introduces more polling (SDKs polling Edge Proxy, and Edge Proxy polling API), but at least it's polling that customers are not charged for. This lets customers scale their applications independently from their Edge Proxies.

This implementation could be more efficient, since we're iterating through all environment key pairs to find the matching server-side key. In any case, the number of environment key pairs served by a single Edge Proxy tends to be small.