### PR TITLE
feat: Add `server.proxy_headers` option

### DIFF
--- a/src/edge_proxy/main.py
+++ b/src/edge_proxy/main.py
@@ -9,6 +9,7 @@ def serve():
         "edge_proxy.server:app",
         host=str(settings.server.host),
         port=settings.server.port,
+        proxy_headers=settings.server.proxy_headers,
         reload=settings.server.reload,
         use_colors=settings.logging.colours,
     )

--- a/src/edge_proxy/settings.py
+++ b/src/edge_proxy/settings.py
@@ -96,6 +96,7 @@ class ServerSettings(BaseModel):
     host: IPvAnyAddress = "0.0.0.0"
     port: int = 8000
     reload: bool = False
+    proxy_headers: bool = False
 
 
 class HealthCheckSettings(BaseModel):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@ import orjson
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 
+from edge_proxy.main import serve
 from tests.fixtures.response_data import environment_1
 
 if typing.TYPE_CHECKING:
@@ -217,3 +218,18 @@ def test_get_identities(
     assert response.status_code == 200
     assert data["traits"] == []
     assert data["flags"]
+
+
+def test_serve_passes_proxy_headers_setting(mocker: MockerFixture) -> None:
+    # Given
+    mock_settings = mocker.patch("edge_proxy.main.get_settings")
+    mock_settings.return_value.server.proxy_headers = True
+
+    mock_uvicorn = mocker.patch("edge_proxy.main.uvicorn.run")
+
+    # When
+    serve()
+
+    # Then
+    _, kwargs = mock_uvicorn.call_args
+    assert kwargs.get("proxy_headers") is True


### PR DESCRIPTION
This enables Uvicorn's `--proxy-headers` option: https://www.uvicorn.org/settings/#http

This is useful when enabling Uvicorn access logs, if we want to see the actual client IPs and not just a loopback address.

This option must be used in combination with the `FORWARDED_ALLOW_IPS` environment variable. I chose not to add it to the config file for simplicity.