### PR TITLE
fix(ci): Don't render config in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim as application
+FROM python:3.12-slim AS application
 
 WORKDIR /app
 
@@ -10,7 +10,6 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY src /app/src
 COPY requirements.lock pyproject.toml /app/
 RUN pip install --no-cache-dir -r requirements.lock
-RUN edge-proxy-render-config
 
 EXPOSE 8000
 

--- a/src/edge_proxy/settings.py
+++ b/src/edge_proxy/settings.py
@@ -59,7 +59,13 @@ def json_config_settings_source() -> dict[str, Any]:
     at the project's root.
     """
     encoding = "utf-8"
-    return json.loads(Path(CONFIG_PATH).read_text(encoding))
+    try:
+        config = json.loads(Path(CONFIG_PATH).read_text(encoding))
+        logger.info(f"Loaded configuration from {CONFIG_PATH}")
+        return config
+    except FileNotFoundError:
+        logger.info(f"Configuration file at {CONFIG_PATH} not found")
+        return {}
 
 
 class EnvironmentKeyPair(BaseModel):


### PR DESCRIPTION
In https://github.com/Flagsmith/edge-proxy/pull/148, we changed the config behaviour so that invalid or missing configurations are rejected with an error. This effectively broke `edge-proxy-render-config` when called without environment variables, which also broke the Docker build: https://github.com/Flagsmith/edge-proxy/actions/runs/14308473957/job/40097587318

Because a config file is no longer required, and we don't need an empty/placeholder config file to show a useful error message, we now don't render a config file at all in the Docker build. If the config file is not found, we now log a message and don't fail with an error. This does not break customers who are mounting/copying their config file into the Edge Proxy container.

This is what running the container with no environment variables or config files looks like now:

```
2025-04-07 13:52:39 [info     ] Configuration file at config.json not found
Traceback (most recent call last):
  File "/opt/venv/bin/edge-proxy-serve", line 8, in <module>
    sys.exit(serve())
             ^^^^^^^
  File "/app/src/edge_proxy/main.py", line 7, in serve
    settings = get_settings()
               ^^^^^^^^^^^^^^
  File "/app/src/edge_proxy/settings.py", line 153, in get_settings
    return AppConfig()
           ^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pydantic_settings/main.py", line 84, in __init__
    super().__init__(
  File "/opt/venv/lib/python3.12/site-packages/pydantic/main.py", line 176, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for AppConfig
environment_key_pairs
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.7/v/missing
```