### PR TITLE
fix: enable follow_redirects for httpx client to handle 307 status codes

### DIFF
--- a/src/edge_proxy/server.py
+++ b/src/edge_proxy/server.py
@@ -21,7 +21,10 @@ settings = get_settings()
 setup_logging(settings.logging)
 environment_service = EnvironmentService(
     LocalMemEnvironmentsCache(),
-    httpx.AsyncClient(timeout=settings.api_poll_timeout_seconds),
+    httpx.AsyncClient(
+        timeout=settings.api_poll_timeout_seconds,
+        follow_redirects=True,
+    ),
     settings,
 )
 


### PR DESCRIPTION
## Problem
The httpx client was not configured to follow redirects, which caused issues when the Flagsmith API returned 307 Temporary Redirect responses.

## Solution
Added `follow_redirects=True` to the httpx.AsyncClient configuration in `src/edge_proxy/server.py`.

## Changes
- Modified `src/edge_proxy/server.py` to enable redirect following
- All existing tests continue to pass
- Code quality checks (ruff linting/formatting) pass

## Testing
- ✅ All 46 tests pass
- ✅ Pre-commit hooks pass
- ✅ No breaking changes to existing functionality

## Impact
This change ensures proper handling of redirect responses from the Flagsmith API, improving reliability when the API returns 307 status codes.