### PR TITLE
ci: remove incorrect filtering preventing latest tag being published

### DIFF
--- a/.github/workflows/docker-publish-image.yml
+++ b/.github/workflows/docker-publish-image.yml
@@ -18,12 +18,8 @@ jobs:
               id: meta
               uses: docker/metadata-action@v5
               with:
-                  images: |
-                      flagsmith/edge-proxy
-                  flavor: |
-                      latest=${{ startsWith(github.ref, 'refs/heads/main') }}
+                  images: flagsmith/edge-proxy
                   tags: |
-                      type=ref,event=branch
                       type=semver,pattern={{version}}
                       type=semver,pattern={{major}}.{{minor}}
 


### PR DESCRIPTION
It looks like we were previously publishing latest tag on pushes to the main branch, but we removed the branch trigger from the workflow so we haven't published the latest image in ~9 months. 

This PR simply makes the `docker/metadata-action` configuration look the same as the one [here](https://github.com/Flagsmith/flagsmith/blob/main/.github/workflows/.reusable-docker-publish.yml#L62-L69) in the core repository. 