### PR TITLE
feat: use-context-evaluation-with-newest-engine-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ name = "edge-proxy"
 license = { file = "LICENSE" }
 dependencies = [
     "fastapi",
-    "flagsmith-flag-engine>=6,<7",
+    "flagsmith-flag-engine>=10,<11",
+    "flagsmith>=5",
     "httpx",
     "marshmallow",
     "orjson",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -6,6 +6,8 @@
 #   features: []
 #   all-features: false
 #   with-sources: false
+#   generate-hashes: false
+#   universal: false
 
 -e file:.
 annotated-types==0.6.0
@@ -16,8 +18,11 @@ anyio==4.3.0
 certifi==2024.2.2
     # via httpcore
     # via httpx
+    # via requests
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.4.4
+    # via requests
 classify-imports==4.2.0
     # via reorder-python-imports
 click==8.1.7
@@ -28,8 +33,11 @@ fastapi==0.110.1
     # via edge-proxy
 filelock==3.13.3
     # via virtualenv
-flagsmith-flag-engine==6.1.0
+flagsmith==5.0.3
     # via edge-proxy
+flagsmith-flag-engine==10.0.3
+    # via edge-proxy
+    # via flagsmith
 freezegun==1.4.0
     # via pytest-freezegun
 h11==0.14.0
@@ -44,8 +52,13 @@ identify==2.5.35
 idna==3.6
     # via anyio
     # via httpx
+    # via requests
 iniconfig==2.0.0
     # via pytest
+iregexp-check==0.1.4
+    # via jsonpath-rfc9535
+jsonpath-rfc9535==0.2.0
+    # via flagsmith-flag-engine
 marshmallow==3.21.1
     # via edge-proxy
 nodeenv==1.8.0
@@ -63,11 +76,7 @@ pre-commit==3.7.0
 pydantic==2.7.1
     # via edge-proxy
     # via fastapi
-    # via flagsmith-flag-engine
-    # via pydantic-collections
     # via pydantic-settings
-pydantic-collections==0.5.4
-    # via flagsmith-flag-engine
 pydantic-core==2.18.2
     # via pydantic
 pydantic-settings==2.2.1
@@ -88,8 +97,15 @@ python-dotenv==1.0.1
     # via pydantic-settings
 pyyaml==6.0.1
     # via pre-commit
+regex==2025.11.3
+    # via jsonpath-rfc9535
 reorder-python-imports==3.12.0
-semver==3.0.2
+requests==2.32.5
+    # via flagsmith
+    # via requests-futures
+requests-futures==1.0.2
+    # via flagsmith
+semver==3.0.4
     # via flagsmith-flag-engine
 setuptools==69.2.0
     # via nodeenv
@@ -98,15 +114,20 @@ six==1.16.0
 sniffio==1.3.1
     # via anyio
     # via httpx
+sseclient-py==1.8.0
+    # via flagsmith
 starlette==0.37.2
     # via fastapi
 structlog==24.1.0
     # via edge-proxy
-typing-extensions==4.11.0
+typing-extensions==4.15.0
     # via fastapi
+    # via flagsmith
+    # via flagsmith-flag-engine
     # via pydantic
-    # via pydantic-collections
     # via pydantic-core
+urllib3==2.6.2
+    # via requests
 uvicorn==0.29.0
     # via edge-proxy
 virtualenv==20.25.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -6,6 +6,8 @@
 #   features: []
 #   all-features: false
 #   with-sources: false
+#   generate-hashes: false
+#   universal: false
 
 -e file:.
 annotated-types==0.6.0
@@ -16,12 +18,18 @@ anyio==4.3.0
 certifi==2024.2.2
     # via httpcore
     # via httpx
+    # via requests
+charset-normalizer==3.4.4
+    # via requests
 click==8.1.7
     # via uvicorn
 fastapi==0.110.1
     # via edge-proxy
-flagsmith-flag-engine==6.1.0
+flagsmith==5.0.3
     # via edge-proxy
+flagsmith-flag-engine==10.0.3
+    # via edge-proxy
+    # via flagsmith
 h11==0.14.0
     # via httpcore
     # via uvicorn
@@ -32,6 +40,11 @@ httpx==0.27.0
 idna==3.6
     # via anyio
     # via httpx
+    # via requests
+iregexp-check==0.1.4
+    # via jsonpath-rfc9535
+jsonpath-rfc9535==0.2.0
+    # via flagsmith-flag-engine
 marshmallow==3.21.1
     # via edge-proxy
 orjson==3.10.0
@@ -41,11 +54,7 @@ packaging==24.0
 pydantic==2.7.1
     # via edge-proxy
     # via fastapi
-    # via flagsmith-flag-engine
-    # via pydantic-collections
     # via pydantic-settings
-pydantic-collections==0.5.4
-    # via flagsmith-flag-engine
 pydantic-core==2.18.2
     # via pydantic
 pydantic-settings==2.2.1
@@ -55,19 +64,31 @@ python-decouple==3.8
 python-dotenv==1.0.1
     # via edge-proxy
     # via pydantic-settings
-semver==3.0.2
+regex==2025.11.3
+    # via jsonpath-rfc9535
+requests==2.32.5
+    # via flagsmith
+    # via requests-futures
+requests-futures==1.0.2
+    # via flagsmith
+semver==3.0.4
     # via flagsmith-flag-engine
 sniffio==1.3.1
     # via anyio
     # via httpx
+sseclient-py==1.8.0
+    # via flagsmith
 starlette==0.37.2
     # via fastapi
 structlog==24.1.0
     # via edge-proxy
-typing-extensions==4.11.0
+typing-extensions==4.15.0
     # via fastapi
+    # via flagsmith
+    # via flagsmith-flag-engine
     # via pydantic
-    # via pydantic-collections
     # via pydantic-core
+urllib3==2.6.2
+    # via requests
 uvicorn==0.29.0
     # via edge-proxy

--- a/src/edge_proxy/cache.py
+++ b/src/edge_proxy/cache.py
@@ -1,6 +1,6 @@
 from abc import ABC
-from collections import defaultdict
 from typing import Any
+
 from edge_proxy.feature_utils import build_feature_types_lookup
 
 
@@ -38,13 +38,6 @@ class BaseEnvironmentsCache(ABC):
     def get_feature_types(self, environment_api_key: str) -> dict[int, str] | None:
         return None
 
-    def get_identity(
-        self,
-        environment_api_key: str,
-        identifier: str,
-    ) -> dict[str, Any]:
-        raise NotImplementedError()
-
 
 _LocalCacheDict = dict[str, dict[str, Any]]
 
@@ -54,7 +47,6 @@ class LocalMemEnvironmentsCache(BaseEnvironmentsCache):
         super().__init__(*args, **kwargs)
         self._environment_cache: _LocalCacheDict = {}
         self._feature_types_cache: dict[str, dict[int, str]] = {}
-        self._identity_override_cache = defaultdict[str, _LocalCacheDict](dict)
 
     def _put_environment(
         self,
@@ -67,13 +59,6 @@ class LocalMemEnvironmentsCache(BaseEnvironmentsCache):
             environment_document
         )
 
-        new_overrides = environment_document.get("identity_overrides") or []
-        self._identity_override_cache[environment_api_key] = {
-            identifier: identity_document
-            for identity_document in new_overrides
-            if (identifier := identity_document.get("identifier"))
-        }
-
     def get_environment(
         self,
         environment_api_key: str,
@@ -82,13 +67,3 @@ class LocalMemEnvironmentsCache(BaseEnvironmentsCache):
 
     def get_feature_types(self, environment_api_key: str) -> dict[int, str] | None:
         return self._feature_types_cache.get(environment_api_key)
-
-    def get_identity(
-        self,
-        environment_api_key: str,
-        identifier: str,
-    ) -> dict[str, Any]:
-        return self._identity_override_cache[environment_api_key].get(identifier) or {
-            "environment_api_key": environment_api_key,
-            "identifier": identifier,
-        }

--- a/src/edge_proxy/cache.py
+++ b/src/edge_proxy/cache.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Any
 
 from edge_proxy.feature_utils import build_feature_types_lookup
@@ -25,18 +25,18 @@ class BaseEnvironmentsCache(ABC):
             return True
         return False
 
+    @abstractmethod
     def _put_environment(
         self,
         environment_api_key: str,
         environment_document: dict[str, Any],
-    ) -> None:
-        raise NotImplementedError()
+    ) -> None: ...
 
-    def get_environment(self, environment_api_key: str) -> dict[str, Any] | None:
-        raise NotImplementedError()
+    @abstractmethod
+    def get_environment(self, environment_api_key: str) -> dict[str, Any] | None: ...
 
-    def get_feature_types(self, environment_api_key: str) -> dict[int, str] | None:
-        return None
+    @abstractmethod
+    def get_feature_types(self, environment_api_key: str) -> dict[int, str] | None: ...
 
 
 _LocalCacheDict = dict[str, dict[str, Any]]

--- a/src/edge_proxy/environments.py
+++ b/src/edge_proxy/environments.py
@@ -102,6 +102,12 @@ class EnvironmentService:
                 if not filtered:
                     raise FeatureNotFoundError()
 
+                hide_disabled_flags = environment_document.get("project", {}).get(
+                    "hide_disabled_flags", False
+                )
+                if hide_disabled_flags and not flag_result.get("enabled", False):
+                    raise FeatureNotFoundError()
+
             data = map_flag_result_to_response_data(flag_result, feature_types)
 
         else:
@@ -111,11 +117,11 @@ class EnvironmentService:
                 flags = filter_out_server_key_only_flags(
                     flags, server_key_only_feature_ids
                 )
+                hide_disabled_flags = environment_document.get("project", {}).get(
+                    "hide_disabled_flags", False
+                )
+                flags = filter_disabled_flags(flags, hide_disabled_flags)
 
-            hide_disabled_flags = environment_document.get("project", {}).get(
-                "hide_disabled_flags", False
-            )
-            flags = filter_disabled_flags(flags, hide_disabled_flags)
             data = map_flag_results_to_response_data(flags, feature_types)
 
         return data
@@ -142,11 +148,10 @@ class EnvironmentService:
         flags = list(evaluation_result["flags"].values())
         if not is_server_key:
             flags = filter_out_server_key_only_flags(flags, server_key_only_feature_ids)
-
-        hide_disabled_flags = environment_document.get("project", {}).get(
-            "hide_disabled_flags", False
-        )
-        flags = filter_disabled_flags(flags, hide_disabled_flags)
+            hide_disabled_flags = environment_document.get("project", {}).get(
+                "hide_disabled_flags", False
+            )
+            flags = filter_disabled_flags(flags, hide_disabled_flags)
 
         data = {
             "traits": map_traits_to_response_data(input_data.traits),

--- a/src/edge_proxy/environments.py
+++ b/src/edge_proxy/environments.py
@@ -32,7 +32,6 @@ SERVER_API_KEY_PREFIX = "ser."
 def _filter_disabled_flags(
     flags: list[dict[str, Any]], hide_disabled_flags: bool
 ) -> list[dict[str, Any]]:
-    """Filter out disabled flags if hide_disabled_flags is enabled."""
     if not hide_disabled_flags:
         return flags
     return [flag for flag in flags if flag.get("enabled", False)]
@@ -93,20 +92,15 @@ class EnvironmentService:
             "hide_disabled_flags", False
         )
 
-        # Build evaluation context from environment document
         context = map_environment_document_to_context(environment_document)
-
-        # Get evaluation result
         evaluation_result = get_evaluation_result(context)
 
         if feature:
-            # Get specific feature
             if feature not in evaluation_result["flags"]:
                 raise FeatureNotFoundError()
 
             flag_result = evaluation_result["flags"][feature]
 
-            # Filter server-key-only features if not a server key
             if not is_server_key:
                 filtered = filter_out_server_key_only_flags(
                     [flag_result], server_key_only_feature_ids
@@ -117,18 +111,14 @@ class EnvironmentService:
             data = map_flag_result_to_response_data(flag_result)
 
         else:
-            # Get all features
             flags = list(evaluation_result["flags"].values())
 
-            # Filter server-key-only features if not a server key
             if not is_server_key:
                 flags = filter_out_server_key_only_flags(
                     flags, server_key_only_feature_ids
                 )
 
-            # Filter disabled flags if hide_disabled_flags is enabled
             flags = _filter_disabled_flags(flags, hide_disabled_flags)
-
             data = map_flag_results_to_response_data(flags)
 
         return data
@@ -145,25 +135,19 @@ class EnvironmentService:
             "hide_disabled_flags", False
         )
 
-        # Build evaluation context from environment document
         context = map_environment_document_to_context(environment_document)
-
-        # Add identity to context
         context = map_context_and_identity_data_to_context(
             context=context,
             identifier=input_data.identifier,
             traits=input_data.traits,
         )
 
-        # Get evaluation result
         evaluation_result = get_evaluation_result(context)
 
-        # Filter server-key-only features if not a server key
         flags = list(evaluation_result["flags"].values())
         if not is_server_key:
             flags = filter_out_server_key_only_flags(flags, server_key_only_feature_ids)
 
-        # Filter disabled flags if hide_disabled_flags is enabled
         flags = _filter_disabled_flags(flags, hide_disabled_flags)
 
         data = {

--- a/src/edge_proxy/environments.py
+++ b/src/edge_proxy/environments.py
@@ -157,6 +157,7 @@ class EnvironmentService:
             flags = filter_disabled_flags(flags, hide_disabled_flags)
 
         return {
+            "identifier": input_data.identifier,
             "traits": map_traits_to_response_data(input_data.traits),
             "flags": map_flag_results_to_response_data(flags, feature_types),
         }

--- a/src/edge_proxy/environments.py
+++ b/src/edge_proxy/environments.py
@@ -84,7 +84,11 @@ class EnvironmentService:
         server_key_only_feature_ids = environment_document.get("project", {}).get(
             "server_key_only_feature_ids", []
         )
-        feature_types = build_feature_types_lookup(environment_document)
+        feature_types = None
+        if hasattr(self.cache, "get_feature_types"):
+            feature_types = self.cache.get_feature_types(environment_key)
+        if feature_types is None:
+            feature_types = build_feature_types_lookup(environment_document)
 
         context = map_environment_document_to_context(environment_document)
         evaluation_result = get_evaluation_result(context)
@@ -134,7 +138,12 @@ class EnvironmentService:
         server_key_only_feature_ids = environment_document.get("project", {}).get(
             "server_key_only_feature_ids", []
         )
-        feature_types = build_feature_types_lookup(environment_document)
+
+        feature_types = None
+        if hasattr(self.cache, "get_feature_types"):
+            feature_types = self.cache.get_feature_types(environment_key)
+        if feature_types is None:
+            feature_types = build_feature_types_lookup(environment_document)
 
         environment_context = map_environment_document_to_context(environment_document)
         context = map_context_and_identity_data_to_context(

--- a/src/edge_proxy/environments.py
+++ b/src/edge_proxy/environments.py
@@ -77,8 +77,8 @@ class EnvironmentService:
             self.last_updated_at = datetime.now()
 
     def get_flags_response_data(
-        self, environment_key: str, feature: str = None
-    ) -> dict[str, Any]:
+        self, environment_key: str, feature: str = ""
+    ) -> dict[str, Any] | list[dict[str, Any]]:
         environment_document = self.get_environment(environment_key=environment_key)
         is_server_key = environment_key.startswith(SERVER_API_KEY_PREFIX)
         server_key_only_feature_ids = environment_document.get("project", {}).get(
@@ -92,6 +92,7 @@ class EnvironmentService:
 
         context = map_environment_document_to_context(environment_document)
         evaluation_result = get_evaluation_result(context)
+        data: dict[str, Any] | list[dict[str, Any]]
 
         if feature:
             if feature not in evaluation_result["flags"]:

--- a/src/edge_proxy/environments.py
+++ b/src/edge_proxy/environments.py
@@ -16,6 +16,7 @@ from orjson import orjson
 from edge_proxy.cache import BaseEnvironmentsCache, LocalMemEnvironmentsCache
 from edge_proxy.exceptions import FeatureNotFoundError, FlagsmithUnknownKeyError
 from edge_proxy.feature_utils import (
+    build_feature_types_lookup,
     filter_disabled_flags,
     filter_out_server_key_only_flags,
 )
@@ -83,10 +84,7 @@ class EnvironmentService:
         server_key_only_feature_ids = environment_document.get("project", {}).get(
             "server_key_only_feature_ids", []
         )
-        feature_types = {
-            fs["feature"]["id"]: fs["feature"].get("type", "STANDARD")
-            for fs in environment_document.get("feature_states", [])
-        }
+        feature_types = build_feature_types_lookup(environment_document)
 
         context = map_environment_document_to_context(environment_document)
         evaluation_result = get_evaluation_result(context)
@@ -130,10 +128,7 @@ class EnvironmentService:
         server_key_only_feature_ids = environment_document.get("project", {}).get(
             "server_key_only_feature_ids", []
         )
-        feature_types = {
-            fs["feature"]["id"]: fs["feature"].get("type", "STANDARD")
-            for fs in environment_document.get("feature_states", [])
-        }
+        feature_types = build_feature_types_lookup(environment_document)
 
         environment_context = map_environment_document_to_context(environment_document)
         context = map_context_and_identity_data_to_context(

--- a/src/edge_proxy/environments.py
+++ b/src/edge_proxy/environments.py
@@ -21,6 +21,7 @@ from edge_proxy.feature_utils import (
     filter_out_server_key_only_flags,
 )
 from edge_proxy.mappers import (
+    convert_traits_to_dict,
     map_flag_result_to_response_data,
     map_flag_results_to_response_data,
     map_traits_to_response_data,
@@ -143,7 +144,7 @@ class EnvironmentService:
         context = map_context_and_identity_data_to_context(
             context=environment_context,
             identifier=input_data.identifier,
-            traits=input_data.traits,
+            traits=convert_traits_to_dict(input_data.traits),
         )
         evaluation_result = get_evaluation_result(context)
 

--- a/src/edge_proxy/feature_utils.py
+++ b/src/edge_proxy/feature_utils.py
@@ -1,4 +1,5 @@
 from typing import Any
+from flag_engine.result.types import FlagResult
 
 
 def build_feature_types_lookup(
@@ -11,9 +12,9 @@ def build_feature_types_lookup(
 
 
 def filter_out_server_key_only_flags(
-    flags: list[dict[str, Any]],
+    flags: list[FlagResult[Any]],
     server_key_only_feature_ids: list[int],
-) -> list[dict[str, Any]]:
+) -> list[FlagResult[Any]]:
     return [
         flag
         for flag in flags
@@ -22,8 +23,8 @@ def filter_out_server_key_only_flags(
 
 
 def filter_disabled_flags(
-    flags: list[dict[str, Any]], hide_disabled: bool
-) -> list[dict[str, Any]]:
+    flags: list[FlagResult[Any]], hide_disabled: bool
+) -> list[FlagResult[Any]]:
     if not hide_disabled:
         return flags
     return [flag for flag in flags if flag.get("enabled", False)]

--- a/src/edge_proxy/feature_utils.py
+++ b/src/edge_proxy/feature_utils.py
@@ -5,16 +5,6 @@ def filter_out_server_key_only_flags(
     flags: list[dict[str, Any]],
     server_key_only_feature_ids: list[int],
 ) -> list[dict[str, Any]]:
-    """
-    Filter out server-key-only flags from the list.
-
-    Args:
-        flags: List of flag results
-        server_key_only_feature_ids: List of feature IDs that are server-key-only
-
-    Returns:
-        Filtered list of flags excluding server-key-only features
-    """
     return [
         flag
         for flag in flags
@@ -25,16 +15,6 @@ def filter_out_server_key_only_flags(
 def filter_disabled_flags(
     flags: list[dict[str, Any]], hide_disabled: bool
 ) -> list[dict[str, Any]]:
-    """
-    Filter out disabled flags if hide_disabled is enabled.
-
-    Args:
-        flags: List of flag results
-        hide_disabled: Whether to filter out disabled flags
-
-    Returns:
-        Filtered list of flags excluding disabled ones if hide_disabled is True
-    """
     if not hide_disabled:
         return flags
     return [flag for flag in flags if flag.get("enabled", False)]

--- a/src/edge_proxy/feature_utils.py
+++ b/src/edge_proxy/feature_utils.py
@@ -1,14 +1,22 @@
-from flag_engine.environments.models import EnvironmentModel
-from flag_engine.features.models import FeatureStateModel
+from typing import Any
 
 
-def filter_out_server_key_only_feature_states(
-    feature_states: list[FeatureStateModel],
-    environment: EnvironmentModel,
-) -> list[FeatureStateModel]:
+def filter_out_server_key_only_flags(
+    flags: list[dict[str, Any]],
+    server_key_only_feature_ids: list[int],
+) -> list[dict[str, Any]]:
+    """
+    Filter out server-key-only flags from the list.
+
+    Args:
+        flags: List of flag results
+        server_key_only_feature_ids: List of feature IDs that are server-key-only
+
+    Returns:
+        Filtered list of flags excluding server-key-only features
+    """
     return [
-        feature_state
-        for feature_state in feature_states
-        if feature_state.feature.id
-        not in environment.project.server_key_only_feature_ids
+        flag
+        for flag in flags
+        if flag.get("metadata", {}).get("id") not in server_key_only_feature_ids
     ]

--- a/src/edge_proxy/feature_utils.py
+++ b/src/edge_proxy/feature_utils.py
@@ -1,6 +1,15 @@
 from typing import Any
 
 
+def build_feature_types_lookup(
+    environment_document: dict[str, Any],
+) -> dict[int, str]:
+    return {
+        fs["feature"]["id"]: fs["feature"].get("type", "STANDARD")
+        for fs in environment_document.get("feature_states", [])
+    }
+
+
 def filter_out_server_key_only_flags(
     flags: list[dict[str, Any]],
     server_key_only_feature_ids: list[int],

--- a/src/edge_proxy/feature_utils.py
+++ b/src/edge_proxy/feature_utils.py
@@ -20,3 +20,21 @@ def filter_out_server_key_only_flags(
         for flag in flags
         if flag.get("metadata", {}).get("id") not in server_key_only_feature_ids
     ]
+
+
+def filter_disabled_flags(
+    flags: list[dict[str, Any]], hide_disabled: bool
+) -> list[dict[str, Any]]:
+    """
+    Filter out disabled flags if hide_disabled is enabled.
+
+    Args:
+        flags: List of flag results
+        hide_disabled: Whether to filter out disabled flags
+
+    Returns:
+        Filtered list of flags excluding disabled ones if hide_disabled is True
+    """
+    if not hide_disabled:
+        return flags
+    return [flag for flag in flags if flag.get("enabled", False)]

--- a/src/edge_proxy/mappers.py
+++ b/src/edge_proxy/mappers.py
@@ -1,10 +1,7 @@
 from typing import Any
+
 from flag_engine.engine import ContextValue
 from flag_engine.result.types import FlagResult
-
-from edge_proxy.schemas import APIFeatureStateSchema
-
-_api_feature_state_schema = APIFeatureStateSchema()
 
 
 def map_flag_result_to_response_data(
@@ -37,5 +34,4 @@ def map_flag_results_to_response_data(
 def map_traits_to_response_data(
     traits: dict[str, ContextValue],
 ) -> list[dict[str, Any]]:
-    """Convert traits dict to API response format (list of trait objects)."""
     return [{"trait_key": k, "trait_value": v} for k, v in traits.items()]

--- a/src/edge_proxy/mappers.py
+++ b/src/edge_proxy/mappers.py
@@ -1,33 +1,37 @@
-from typing import Any, Optional
-
-from flag_engine.features.models import FeatureStateModel
-from flag_engine.identities.traits.models import TraitModel
+from typing import Any
+from flag_engine.engine import ContextValue
 
 from edge_proxy.schemas import APIFeatureStateSchema
 
 _api_feature_state_schema = APIFeatureStateSchema()
 
 
-def map_feature_state_to_response_data(
-    feature_state: FeatureStateModel,
-    identity_hash_key: Optional[str] = None,
+def map_flag_result_to_response_data(
+    flag_result: dict[str, Any],
 ) -> dict[str, Any]:
-    data = _api_feature_state_schema.dump(feature_state)
-    data["feature_state_value"] = feature_state.get_value(identity_id=identity_hash_key)
-    return data
+    """Map a single flag result to API response format."""
+    return {
+        "feature": {
+            "id": flag_result.get("metadata", {}).get("id"),
+            "name": flag_result["name"],
+            "type": flag_result.get("type", "STANDARD"),
+        },
+        "enabled": flag_result["enabled"],
+        "feature_state_value": flag_result["value"],
+    }
 
 
-def map_feature_states_to_response_data(
-    feature_states: list[FeatureStateModel],
-    identity_hash_key: Optional[str] = None,
+def map_flag_results_to_response_data(
+    flag_results: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
+    """Map multiple flag results to API response format."""
     return [
-        map_feature_state_to_response_data(feature_state, identity_hash_key)
-        for feature_state in feature_states
+        map_flag_result_to_response_data(flag_result) for flag_result in flag_results
     ]
 
 
 def map_traits_to_response_data(
-    traits: list[TraitModel],
+    traits: dict[str, ContextValue],
 ) -> list[dict[str, Any]]:
-    return [trait.model_dump() for trait in traits]
+    """Convert traits dict to API response format (list of trait objects)."""
+    return [{"trait_key": k, "trait_value": v} for k, v in traits.items()]

--- a/src/edge_proxy/mappers.py
+++ b/src/edge_proxy/mappers.py
@@ -1,23 +1,10 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flag_engine.engine import ContextValue
 from flag_engine.result.types import FlagResult
 
-
-def convert_feature_value_to_type(value: Any) -> Any:
-    if value is None or not isinstance(value, str):
-        return value
-    try:
-        int_val = int(value)
-        if str(int_val) == value:
-            return int_val
-    except ValueError:
-        pass
-    if value.lower() == "true":
-        return True
-    if value.lower() == "false":
-        return False
-    return value
+if TYPE_CHECKING:
+    from edge_proxy.models import TraitModel
 
 
 def map_flag_result_to_response_data(
@@ -33,7 +20,7 @@ def map_flag_result_to_response_data(
             "type": feature_type,
         },
         "enabled": flag_result["enabled"],
-        "feature_state_value": convert_feature_value_to_type(flag_result["value"]),
+        "feature_state_value": flag_result["value"],
     }
 
 
@@ -47,7 +34,11 @@ def map_flag_results_to_response_data(
     ]
 
 
+def convert_traits_to_dict(traits: list["TraitModel"]) -> dict[str, ContextValue]:
+    return {trait.trait_key: trait.trait_value for trait in traits}
+
+
 def map_traits_to_response_data(
-    traits: dict[str, ContextValue],
+    traits: list["TraitModel"],
 ) -> list[dict[str, Any]]:
-    return [{"trait_key": k, "trait_value": v} for k, v in traits.items()]
+    return [{"trait_key": t.trait_key, "trait_value": t.trait_value} for t in traits]

--- a/src/edge_proxy/mappers.py
+++ b/src/edge_proxy/mappers.py
@@ -4,6 +4,22 @@ from flag_engine.engine import ContextValue
 from flag_engine.result.types import FlagResult
 
 
+def convert_feature_value_to_type(value: Any) -> Any:
+    if value is None or not isinstance(value, str):
+        return value
+    try:
+        int_val = int(value)
+        if str(int_val) == value:
+            return int_val
+    except ValueError:
+        pass
+    if value.lower() == "true":
+        return True
+    if value.lower() == "false":
+        return False
+    return value
+
+
 def map_flag_result_to_response_data(
     flag_result: FlagResult[Any],
     feature_types: dict[int, str] | None = None,
@@ -17,7 +33,7 @@ def map_flag_result_to_response_data(
             "type": feature_type,
         },
         "enabled": flag_result["enabled"],
-        "feature_state_value": flag_result["value"],
+        "feature_state_value": convert_feature_value_to_type(flag_result["value"]),
     }
 
 

--- a/src/edge_proxy/mappers.py
+++ b/src/edge_proxy/mappers.py
@@ -1,5 +1,6 @@
 from typing import Any
 from flag_engine.engine import ContextValue
+from flag_engine.result.types import FlagResult
 
 from edge_proxy.schemas import APIFeatureStateSchema
 
@@ -7,7 +8,7 @@ _api_feature_state_schema = APIFeatureStateSchema()
 
 
 def map_flag_result_to_response_data(
-    flag_result: dict[str, Any],
+    flag_result: FlagResult[Any],
     feature_types: dict[int, str] | None = None,
 ) -> dict[str, Any]:
     feature_id = flag_result.get("metadata", {}).get("id")
@@ -24,7 +25,7 @@ def map_flag_result_to_response_data(
 
 
 def map_flag_results_to_response_data(
-    flag_results: list[dict[str, Any]],
+    flag_results: list[FlagResult[Any]],
     feature_types: dict[int, str] | None = None,
 ) -> list[dict[str, Any]]:
     return [

--- a/src/edge_proxy/mappers.py
+++ b/src/edge_proxy/mappers.py
@@ -8,13 +8,15 @@ _api_feature_state_schema = APIFeatureStateSchema()
 
 def map_flag_result_to_response_data(
     flag_result: dict[str, Any],
+    feature_types: dict[int, str] | None = None,
 ) -> dict[str, Any]:
-    """Map a single flag result to API response format."""
+    feature_id = flag_result.get("metadata", {}).get("id")
+    feature_type = (feature_types or {}).get(feature_id, "STANDARD")
     return {
         "feature": {
-            "id": flag_result.get("metadata", {}).get("id"),
+            "id": feature_id,
             "name": flag_result["name"],
-            "type": flag_result.get("type", "STANDARD"),
+            "type": feature_type,
         },
         "enabled": flag_result["enabled"],
         "feature_state_value": flag_result["value"],
@@ -23,10 +25,11 @@ def map_flag_result_to_response_data(
 
 def map_flag_results_to_response_data(
     flag_results: list[dict[str, Any]],
+    feature_types: dict[int, str] | None = None,
 ) -> list[dict[str, Any]]:
-    """Map multiple flag results to API response format."""
     return [
-        map_flag_result_to_response_data(flag_result) for flag_result in flag_results
+        map_flag_result_to_response_data(flag_result, feature_types)
+        for flag_result in flag_results
     ]
 
 

--- a/src/edge_proxy/models.py
+++ b/src/edge_proxy/models.py
@@ -11,7 +11,7 @@ class IdentityWithTraits(BaseModel):
     @field_validator("traits", mode="before")
     @classmethod
     def convert_traits_list_to_dict(cls, v: Any) -> dict[str, ContextValue]:
-        """Convert traits from list format to dict format for backward compatibility."""
+        """Convert legacy list format to dict."""
         if isinstance(v, list):
             return {trait["trait_key"]: trait["trait_value"] for trait in v}
         return v
@@ -21,7 +21,7 @@ class IdentityWithTraits(BaseModel):
     def validate_trait_value_length(
         cls, v: dict[str, ContextValue]
     ) -> dict[str, ContextValue]:
-        """Validate that trait values don't exceed 2000 characters."""
+        """Enforce 2000 char limit on trait values."""
         for key, value in v.items():
             if isinstance(value, str) and len(value) > 2000:
                 raise PydanticCustomError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ def environment_service() -> "EnvironmentService":
 
 
 @pytest.fixture
-def mocked_environment_cache(mocker: MockerFixture):
+def mocked_environment_cache(mocker: MockerFixture) -> typing.Any:
     mock = mocker.patch("edge_proxy.server.environment_service.cache")
     mock.get_environment.return_value = None
     mock.get_feature_types.return_value = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,14 @@ def environment_service() -> "EnvironmentService":
 
 
 @pytest.fixture
+def mocked_environment_cache(mocker: MockerFixture):
+    mock = mocker.patch("edge_proxy.server.environment_service.cache")
+    mock.get_environment.return_value = None
+    mock.get_feature_types.return_value = None
+    return mock
+
+
+@pytest.fixture
 def client():
     from edge_proxy.server import app
 

--- a/tests/fixtures/response_data.py
+++ b/tests/fixtures/response_data.py
@@ -50,6 +50,30 @@ _environment_feature_state_3 = {
 }
 
 
+_multivariate_feature_state = {
+    "multivariate_feature_state_values": [
+        {
+            "id": 1,
+            "multivariate_feature_option": {"id": 1, "value": "variant_a"},
+            "percentage_allocation": 50,
+        },
+        {
+            "id": 2,
+            "multivariate_feature_option": {"id": 2, "value": "variant_b"},
+            "percentage_allocation": 50,
+        },
+    ],
+    "feature_state_value": "control",
+    "featurestate_uuid": "e4g9c5d3-8b52-6g79-1hfd-cg8g54f51i0g",
+    "feature": {
+        "name": "mv_feature",
+        "type": "MULTIVARIATE",
+        "id": 4,
+    },
+    "enabled": True,
+}
+
+
 _segment_1 = {
     "name": "segment_1",
     "rules": [
@@ -156,4 +180,34 @@ environment_with_hide_disabled_flags = {
     "api_key": "env_with_hide_disabled_key",
     "project": _project_with_hide_disabled_flags,
     "id": 2,
+}
+
+
+_project_with_multivariate = {
+    "name": "project-with-multivariate",
+    "organisation": {
+        "feature_analytics": False,
+        "name": "org-1",
+        "id": 1,
+        "persist_trait_data": True,
+        "stop_serving_flags": False,
+    },
+    "id": 3,
+    "hide_disabled_flags": False,
+    "segments": [],
+    "server_key_only_feature_ids": [],
+}
+
+
+environment_with_multivariate_feature = {
+    "updated_at": "1969-07-20T20:17:40Z",
+    "name": "environment_with_multivariate",
+    "feature_states": [
+        _environment_feature_state_1,
+        _multivariate_feature_state,
+    ],
+    "identity_overrides": [],
+    "api_key": "env_with_multivariate_key",
+    "project": _project_with_multivariate,
+    "id": 3,
 }

--- a/tests/fixtures/response_data.py
+++ b/tests/fixtures/response_data.py
@@ -1,6 +1,7 @@
 _segment_override_feature_state = {
     "multivariate_feature_state_values": [],
     "feature_state_value": "segment_override",
+    "featurestate_uuid": "a1b2c3d4-5e6f-7g8h-9i0j-k1l2m3n4o5p6",
     "feature": {
         "name": "feature_2",
         "type": "STANDARD",
@@ -13,6 +14,7 @@ _segment_override_feature_state = {
 _environment_feature_state_1 = {
     "multivariate_feature_state_values": [],
     "feature_state_value": "feature_1_value",
+    "featurestate_uuid": "8c0a77ba-d07c-4e48-9adb-de5e21c29f7d",
     "feature": {
         "name": "feature_1",
         "type": "STANDARD",
@@ -25,6 +27,7 @@ _environment_feature_state_1 = {
 _environment_feature_state_2 = {
     "multivariate_feature_state_values": [],
     "feature_state_value": "2.3",
+    "featurestate_uuid": "f2d7a3b9-8c41-4e57-9fdb-ae6e32d39g8e",
     "feature": {
         "name": "feature_2",
         "type": "STANDARD",
@@ -37,6 +40,7 @@ _environment_feature_state_2 = {
 _environment_feature_state_3 = {
     "multivariate_feature_state_values": [],
     "feature_state_value": None,
+    "featurestate_uuid": "d3f8b4c2-7a41-5f68-0gec-bf7f43e40h9f",
     "feature": {
         "name": "feature_3",
         "type": "STANDARD",
@@ -92,6 +96,7 @@ environment_1_api_key = "environment_1_api_key"
 
 environment_1 = {
     "updated_at": "1969-07-20T20:17:40Z",
+    "name": "environment_1",
     "feature_states": [
         _environment_feature_state_1,
         _environment_feature_state_2,
@@ -119,4 +124,36 @@ environment_1 = {
     "api_key": environment_1_api_key,
     "project": _project_1,
     "id": 1,
+}
+
+
+# Project with hide_disabled_flags enabled
+_project_with_hide_disabled_flags = {
+    "name": "project-with-hide-disabled-flags",
+    "organisation": {
+        "feature_analytics": False,
+        "name": "org-1",
+        "id": 1,
+        "persist_trait_data": True,
+        "stop_serving_flags": False,
+    },
+    "id": 2,
+    "hide_disabled_flags": True,
+    "segments": [_segment_1],
+    "server_key_only_feature_ids": [],
+}
+
+
+environment_with_hide_disabled_flags = {
+    "updated_at": "1969-07-20T20:17:40Z",
+    "name": "environment_with_hide_disabled_flags",
+    "feature_states": [
+        _environment_feature_state_1,
+        _environment_feature_state_2,
+        _environment_feature_state_3,
+    ],
+    "identity_overrides": [],
+    "api_key": "env_with_hide_disabled_key",
+    "project": _project_with_hide_disabled_flags,
+    "id": 2,
 }

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -266,6 +266,7 @@ async def test_refresh_environment_caches__deleted_identity_override__cached_exp
         IdentityWithTraits(identifier="overridden-id"),
         environment_1_api_key,
     ) == {
+        "identifier": "overridden-id",
         "flags": [
             {
                 "enabled": True,
@@ -298,6 +299,7 @@ async def test_refresh_environment_caches__deleted_identity_override__cached_exp
     assert environment_service.get_identity_response_data(
         IdentityWithTraits(identifier="overridden-id"), environment_1_api_key
     ) == {
+        "identifier": "overridden-id",
         "flags": [
             {
                 "enabled": False,

--- a/tests/test_mappers.py
+++ b/tests/test_mappers.py
@@ -1,70 +1,34 @@
 from typing import Any
 
 import pytest
-from flag_engine.features.models import FeatureStateModel
-from flag_engine.identities.traits.models import TraitModel
 
 from edge_proxy.mappers import (
-    map_feature_state_to_response_data,
-    map_feature_states_to_response_data,
+    map_flag_result_to_response_data,
+    map_flag_results_to_response_data,
     map_traits_to_response_data,
 )
 
 
 @pytest.fixture()
-def feature_state_model() -> FeatureStateModel:
-    return FeatureStateModel.parse_obj(
-        {
-            "multivariate_feature_state_values": [],
-            "feature_state_value": "feature_1_value",
-            "id": 1,
-            "featurestate_uuid": "2d1831b9-4642-4474-8b09-cdf3872cdc99",
-            "feature_segment": None,
-            "feature": {
-                "name": "feature_1",
-                "type": "STANDARD",
-                "id": 1,
-            },
-            "enabled": False,
-        },
-    )
+def flag_result() -> dict[str, Any]:
+    """Flag result from the new engine API."""
+    return {
+        "name": "feature_1",
+        "enabled": False,
+        "value": "feature_1_value",
+        "metadata": {"id": 1},
+    }
 
 
 @pytest.fixture()
-def multivariate_feature_state_model() -> FeatureStateModel:
-    return FeatureStateModel.parse_obj(
-        {
-            "multivariate_feature_state_values": [
-                {
-                    "mv_fs_value_uuid": "bf83bedd-d9c0-4b47-97f2-84a2559303e9",
-                    "percentage_allocation": 50,
-                    "multivariate_feature_option": {"value": "50_percent", "id": 1},
-                    "id": 1,
-                },
-                {
-                    "mv_fs_value_uuid": "a9c2aba9-ce3a-4333-87f3-d9fa4c5cb9a5",
-                    "percentage_allocation": 10,
-                    "multivariate_feature_option": {"value": "1_percent", "id": 2},
-                    "id": 2,
-                },
-            ],
-            "feature_state_value": None,
-            "featurestate_uuid": "a74bcb0f-b6a3-4636-866e-13e326c80b51",
-            "feature_segment": None,
-            "id": 4,
-            "feature": {
-                "name": "multivariate_feature",
-                "type": "MULTIVARIATE",
-                "id": 4,
-            },
-            "enabled": False,
-        }
-    )
-
-
-@pytest.fixture()
-def trait_model() -> TraitModel:
-    return TraitModel(trait_key="phIndex", trait_value=7.4)
+def multivariate_flag_result() -> dict[str, Any]:
+    """Multivariate flag result from the new engine API."""
+    return {
+        "name": "multivariate_feature",
+        "enabled": False,
+        "value": None,
+        "metadata": {"id": 4},
+    }
 
 
 @pytest.fixture()
@@ -84,22 +48,20 @@ def traits_data(
 
 
 @pytest.fixture()
-def trait_models(trait_model: TraitModel) -> list[TraitModel]:
-    return [
-        trait_model,
-        TraitModel(
-            trait_key="email",
-            trait_value="notarealemail@fictitiousdomain.xyz",
-        ),
-        TraitModel(trait_key="userCategoryId", trait_value=12),
-    ]
+def traits_dict() -> dict[str, Any]:
+    """Traits as dict (new format)."""
+    return {
+        "phIndex": 7.4,
+        "email": "notarealemail@fictitiousdomain.xyz",
+        "userCategoryId": 12,
+    }
 
 
-def test_map_feature_state_to_response_data__return_expected(
-    multivariate_feature_state_model: FeatureStateModel,
+def test_map_flag_result_to_response_data__return_expected(
+    multivariate_flag_result: dict[str, Any],
 ) -> None:
     # When
-    result = map_feature_state_to_response_data(multivariate_feature_state_model)
+    result = map_flag_result_to_response_data(multivariate_flag_result)
 
     # Then
     assert result == {
@@ -107,21 +69,21 @@ def test_map_feature_state_to_response_data__return_expected(
         "feature": {
             "id": 4,
             "name": "multivariate_feature",
-            "type": "MULTIVARIATE",
+            "type": "STANDARD",
         },
         "feature_state_value": None,
     }
 
 
-def test_map_feature_states_to_response_data__return_expected(
-    feature_state_model: FeatureStateModel,
-    multivariate_feature_state_model: FeatureStateModel,
+def test_map_flag_results_to_response_data__return_expected(
+    flag_result: dict[str, Any],
+    multivariate_flag_result: dict[str, Any],
 ) -> None:
     # Given
-    feature_states = [feature_state_model, multivariate_feature_state_model]
+    flag_results = [flag_result, multivariate_flag_result]
 
     # When
-    result = map_feature_states_to_response_data(feature_states)
+    result = map_flag_results_to_response_data(flag_results)
 
     # Then
     assert result == [
@@ -139,7 +101,7 @@ def test_map_feature_states_to_response_data__return_expected(
             "feature": {
                 "id": 4,
                 "name": "multivariate_feature",
-                "type": "MULTIVARIATE",
+                "type": "STANDARD",
             },
             "feature_state_value": None,
         },
@@ -147,11 +109,11 @@ def test_map_feature_states_to_response_data__return_expected(
 
 
 def test_map_traits_to_response_data__return_expected(
-    trait_models: list[TraitModel],
+    traits_dict: dict[str, Any],
     traits_data: list[dict[str, Any]],
 ) -> None:
     # When
-    result = map_traits_to_response_data(trait_models)
+    result = map_traits_to_response_data(traits_dict)
 
     # Then
     assert result == traits_data

--- a/tests/test_mappers.py
+++ b/tests/test_mappers.py
@@ -75,6 +75,27 @@ def test_map_flag_result_to_response_data__return_expected(
     }
 
 
+def test_map_flag_result_to_response_data__with_feature_types__return_expected(
+    multivariate_flag_result: dict[str, Any],
+) -> None:
+    # Given
+    feature_types = {4: "MULTIVARIATE"}
+
+    # When
+    result = map_flag_result_to_response_data(multivariate_flag_result, feature_types)
+
+    # Then
+    assert result == {
+        "enabled": False,
+        "feature": {
+            "id": 4,
+            "name": "multivariate_feature",
+            "type": "MULTIVARIATE",
+        },
+        "feature_state_value": None,
+    }
+
+
 def test_map_flag_results_to_response_data__return_expected(
     flag_result: dict[str, Any],
     multivariate_flag_result: dict[str, Any],
@@ -102,6 +123,40 @@ def test_map_flag_results_to_response_data__return_expected(
                 "id": 4,
                 "name": "multivariate_feature",
                 "type": "STANDARD",
+            },
+            "feature_state_value": None,
+        },
+    ]
+
+
+def test_map_flag_results_to_response_data__with_feature_types__return_expected(
+    flag_result: dict[str, Any],
+    multivariate_flag_result: dict[str, Any],
+) -> None:
+    # Given
+    flag_results = [flag_result, multivariate_flag_result]
+    feature_types = {1: "STANDARD", 4: "MULTIVARIATE"}
+
+    # When
+    result = map_flag_results_to_response_data(flag_results, feature_types)
+
+    # Then
+    assert result == [
+        {
+            "enabled": False,
+            "feature": {
+                "id": 1,
+                "name": "feature_1",
+                "type": "STANDARD",
+            },
+            "feature_state_value": "feature_1_value",
+        },
+        {
+            "enabled": False,
+            "feature": {
+                "id": 4,
+                "name": "multivariate_feature",
+                "type": "MULTIVARIATE",
             },
             "feature_state_value": None,
         },

--- a/tests/test_mappers.py
+++ b/tests/test_mappers.py
@@ -7,6 +7,7 @@ from edge_proxy.mappers import (
     map_flag_results_to_response_data,
     map_traits_to_response_data,
 )
+from edge_proxy.models import TraitModel
 
 
 @pytest.fixture()
@@ -48,13 +49,12 @@ def traits_data(
 
 
 @pytest.fixture()
-def traits_dict() -> dict[str, Any]:
-    """Traits as dict (new format)."""
-    return {
-        "phIndex": 7.4,
-        "email": "notarealemail@fictitiousdomain.xyz",
-        "userCategoryId": 12,
-    }
+def trait_models() -> list[TraitModel]:
+    return [
+        TraitModel(trait_key="phIndex", trait_value=7.4),
+        TraitModel(trait_key="email", trait_value="notarealemail@fictitiousdomain.xyz"),
+        TraitModel(trait_key="userCategoryId", trait_value=12),
+    ]
 
 
 def test_map_flag_result_to_response_data__return_expected(
@@ -164,11 +164,11 @@ def test_map_flag_results_to_response_data__with_feature_types__return_expected(
 
 
 def test_map_traits_to_response_data__return_expected(
-    traits_dict: dict[str, Any],
+    trait_models: list[TraitModel],
     traits_data: list[dict[str, Any]],
 ) -> None:
     # When
-    result = map_traits_to_response_data(traits_dict)
+    result = map_traits_to_response_data(trait_models)
 
     # Then
     assert result == traits_data

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,7 +13,7 @@ def test_identity_with_traits_str():
     expected = "identifier:foo|traits:foo=bar,age=21,is_cool=True"
 
     # When
-    identity_with_traits = IdentityWithTraits.parse_obj(
+    identity_with_traits = IdentityWithTraits.model_validate(
         {"identifier": identifier, "traits": traits}
     )
 
@@ -33,7 +33,7 @@ def test_identity_with_traits_hash():
     expected = hash("identifier:foo|traits:foo=bar,age=21,is_cool=True")
 
     # When
-    identity_with_traits = IdentityWithTraits.parse_obj(
+    identity_with_traits = IdentityWithTraits.model_validate(
         {"identifier": identifier, "traits": traits}
     )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -316,6 +316,11 @@ def test_get_flags__server_key__hide_disabled_flags_enabled__returns_all_flags(
     assert response.status_code == 200
     flags = response.json()
     assert len(flags) == 3
+    # Verify disabled flags are included (bypasses hide_disabled_flags for server keys)
+    flag_names = {f["feature"]["name"] for f in flags}
+    assert "feature_1" in flag_names  # disabled flag
+    assert "feature_2" in flag_names  # enabled flag
+    assert "feature_3" in flag_names  # disabled flag
 
 
 def test_get_flags__client_key__hide_disabled_flags_enabled__single_disabled_feature__returns_404(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -165,6 +165,8 @@ def test_post_identity__invalid_trait_data__expected_response(
     assert response.json()["detail"][-1]["loc"] == [
         "body",
         "traits",
+        0,
+        "trait_value",
     ]
     assert response.json()["detail"][-1]["type"] == "string_too_long"
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -104,6 +104,7 @@ def test_post_identity_with_traits(
         content=orjson.dumps(data),
     )
     assert response.json() == {
+        "identifier": "do_it_all_in_one_go_identity",
         "flags": environment_1_feature_states_response_list_response_with_segment_override,
         "traits": data["traits"],
     }
@@ -134,6 +135,7 @@ def test_post_identity__environment_with_overrides__expected_response(
 
     # Then
     assert response.json() == {
+        "identifier": identifier,
         "flags": environment_1_feature_states_response_list_response_with_identity_override,
         "traits": [],
     }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,16 +17,12 @@ if typing.TYPE_CHECKING:
 
 
 def test_get_flags(
-    mocker: MockerFixture,
+    mocked_environment_cache,
     environment_1_feature_states_response_list: list[dict],
     client: TestClient,
 ) -> None:
     environment_key = "test_environment_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = environment_1
-    mocked_environment_cache.get_feature_types.return_value = None
     response = client.get(
         "/api/v1/flags", headers={"X-Environment-Key": environment_key}
     )
@@ -35,16 +31,12 @@ def test_get_flags(
 
 
 def test_get_flags_single_feature(
-    mocker: MockerFixture,
+    mocked_environment_cache,
     environment_1_feature_states_response_list: list[dict],
     client: TestClient,
 ) -> None:
     environment_key = "test_environment_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = environment_1
-    mocked_environment_cache.get_feature_types.return_value = None
     response = client.get(
         "/api/v1/flags",
         headers={"X-Environment-Key": environment_key},
@@ -55,16 +47,12 @@ def test_get_flags_single_feature(
 
 
 def test_get_flags_single_feature__server_key_only_feature__return_expected(
-    mocker: MockerFixture,
+    mocked_environment_cache,
     client: TestClient,
 ) -> None:
     # Given
     environment_key = "test_environment_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = environment_1
-    mocked_environment_cache.get_feature_types.return_value = None
 
     # When
     response = client.get(
@@ -82,15 +70,11 @@ def test_get_flags_single_feature__server_key_only_feature__return_expected(
 
 
 def test_get_flags_unknown_key(
-    mocker: MockerFixture,
+    mocked_environment_cache,
     client: TestClient,
 ):
     environment_key = "unknown_environment_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = None
-    mocked_environment_cache.get_feature_types.return_value = None
     response = client.get(
         "/api/v1/flags",
         headers={"X-Environment-Key": environment_key},
@@ -104,16 +88,12 @@ def test_get_flags_unknown_key(
 
 
 def test_post_identity_with_traits(
-    mocker,
+    mocked_environment_cache,
     environment_1_feature_states_response_list_response_with_segment_override,
     client: TestClient,
 ):
     environment_key = "test_environment_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = environment_1
-    mocked_environment_cache.get_feature_types.return_value = None
     data = {
         "traits": [{"trait_value": "test", "trait_key": "first_name"}],
         "identifier": "do_it_all_in_one_go_identity",
@@ -128,8 +108,6 @@ def test_post_identity_with_traits(
         "traits": data["traits"],
     }
     mocked_environment_cache.get_environment.assert_called_with(environment_key)
-    # Note: With engine v10+, we no longer need to fetch identity from cache
-    # The identifier and traits are passed directly to the evaluation context
 
 
 def test_post_identity__environment_with_overrides__expected_response(
@@ -162,16 +140,12 @@ def test_post_identity__environment_with_overrides__expected_response(
 
 
 def test_post_identity__invalid_trait_data__expected_response(
-    mocker: MockerFixture,
+    mocked_environment_cache,
     client: TestClient,
 ) -> None:
     # Given
     environment_key = "test_environment_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = environment_1
-    mocked_environment_cache.get_feature_types.return_value = None
     data = {
         "traits": [{"trait_value": "a" * 2001, "trait_key": "first_name"}],
         "identifier": "do_it_all_in_one_go_identity",
@@ -194,21 +168,13 @@ def test_post_identity__invalid_trait_data__expected_response(
 
 
 def test_get_identities(
-    mocker: MockerFixture,
+    mocked_environment_cache,
     client: TestClient,
 ) -> None:
     x_environment_key = "test_environment_key"
     identifier = "test_identifier"
 
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = environment_1
-    mocked_environment_cache.get_feature_types.return_value = None
-    mocked_environment_cache.get_identity.return_value = {
-        "environment_api_key": x_environment_key,
-        "identifier": identifier,
-    }
 
     response = client.get(
         "/api/v1/identities/",
@@ -286,18 +252,14 @@ def test_get_environment_document_wrong_key(
 
 
 def test_get_flags__client_key__hide_disabled_flags_enabled__only_returns_enabled_flags(
-    mocker: MockerFixture,
+    mocked_environment_cache,
     client: TestClient,
 ) -> None:
     # Given
     environment_key = "test_environment_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = (
         environment_with_hide_disabled_flags
     )
-    mocked_environment_cache.get_feature_types.return_value = None
 
     # When
     response = client.get(
@@ -313,16 +275,12 @@ def test_get_flags__client_key__hide_disabled_flags_enabled__only_returns_enable
 
 
 def test_get_flags__client_key__hide_disabled_flags_disabled__returns_all_flags(
-    mocker: MockerFixture,
+    mocked_environment_cache,
     client: TestClient,
 ) -> None:
     # Given
     environment_key = "test_environment_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = environment_1
-    mocked_environment_cache.get_feature_types.return_value = None
 
     # When
     response = client.get(
@@ -337,18 +295,15 @@ def test_get_flags__client_key__hide_disabled_flags_disabled__returns_all_flags(
 
 def test_get_flags__server_key__hide_disabled_flags_enabled__returns_all_flags(
     mocker: MockerFixture,
+    mocked_environment_cache,
     client: TestClient,
 ) -> None:
     # Given
     server_key = "ser.test_server_key"
     client_key = "test_client_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = (
         environment_with_hide_disabled_flags
     )
-    mocked_environment_cache.get_feature_types.return_value = None
     mocker.patch(
         "edge_proxy.server.environment_service._get_client_key_from_server_key",
         return_value=client_key,
@@ -364,18 +319,14 @@ def test_get_flags__server_key__hide_disabled_flags_enabled__returns_all_flags(
 
 
 def test_get_flags__client_key__hide_disabled_flags_enabled__single_disabled_feature__returns_404(
-    mocker: MockerFixture,
+    mocked_environment_cache,
     client: TestClient,
 ) -> None:
     # Given
     environment_key = "test_environment_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = (
         environment_with_hide_disabled_flags
     )
-    mocked_environment_cache.get_feature_types.return_value = None
 
     # When
     response = client.get(
@@ -389,18 +340,14 @@ def test_get_flags__client_key__hide_disabled_flags_enabled__single_disabled_fea
 
 
 def test_post_identity__client_key__hide_disabled_flags_enabled__only_returns_enabled_flags(
-    mocker: MockerFixture,
+    mocked_environment_cache,
     client: TestClient,
 ) -> None:
     # Given
     environment_key = "test_environment_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = (
         environment_with_hide_disabled_flags
     )
-    mocked_environment_cache.get_feature_types.return_value = None
     data = {
         "identifier": "test_identifier",
         "traits": [],
@@ -423,16 +370,12 @@ def test_post_identity__client_key__hide_disabled_flags_enabled__only_returns_en
 
 
 def test_post_identity__client_key__hide_disabled_flags_disabled__returns_all_flags(
-    mocker: MockerFixture,
+    mocked_environment_cache,
     client: TestClient,
 ) -> None:
     # Given
     environment_key = "test_environment_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = environment_1
-    mocked_environment_cache.get_feature_types.return_value = None
     data = {
         "identifier": "test_identifier",
         "traits": [],
@@ -453,18 +396,14 @@ def test_post_identity__client_key__hide_disabled_flags_disabled__returns_all_fl
 
 
 def test_get_flags__multivariate_feature__returns_correct_type(
-    mocker: MockerFixture,
+    mocked_environment_cache,
     client: TestClient,
 ) -> None:
     # Given
     environment_key = "test_environment_key"
-    mocked_environment_cache = mocker.patch(
-        "edge_proxy.server.environment_service.cache"
-    )
     mocked_environment_cache.get_environment.return_value = (
         environment_with_multivariate_feature
     )
-    mocked_environment_cache.get_feature_types.return_value = None
 
     # When
     response = client.get(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,6 +25,7 @@ def test_get_flags(
         "edge_proxy.server.environment_service.cache"
     )
     mocked_environment_cache.get_environment.return_value = environment_1
+    mocked_environment_cache.get_feature_types.return_value = None
     response = client.get(
         "/api/v1/flags", headers={"X-Environment-Key": environment_key}
     )
@@ -42,6 +43,7 @@ def test_get_flags_single_feature(
         "edge_proxy.server.environment_service.cache"
     )
     mocked_environment_cache.get_environment.return_value = environment_1
+    mocked_environment_cache.get_feature_types.return_value = None
     response = client.get(
         "/api/v1/flags",
         headers={"X-Environment-Key": environment_key},
@@ -61,6 +63,7 @@ def test_get_flags_single_feature__server_key_only_feature__return_expected(
         "edge_proxy.server.environment_service.cache"
     )
     mocked_environment_cache.get_environment.return_value = environment_1
+    mocked_environment_cache.get_feature_types.return_value = None
 
     # When
     response = client.get(
@@ -86,6 +89,7 @@ def test_get_flags_unknown_key(
         "edge_proxy.server.environment_service.cache"
     )
     mocked_environment_cache.get_environment.return_value = None
+    mocked_environment_cache.get_feature_types.return_value = None
     response = client.get(
         "/api/v1/flags",
         headers={"X-Environment-Key": environment_key},
@@ -108,6 +112,7 @@ def test_post_identity_with_traits(
         "edge_proxy.server.environment_service.cache"
     )
     mocked_environment_cache.get_environment.return_value = environment_1
+    mocked_environment_cache.get_feature_types.return_value = None
     data = {
         "traits": [{"trait_value": "test", "trait_key": "first_name"}],
         "identifier": "do_it_all_in_one_go_identity",
@@ -165,6 +170,7 @@ def test_post_identity__invalid_trait_data__expected_response(
         "edge_proxy.server.environment_service.cache"
     )
     mocked_environment_cache.get_environment.return_value = environment_1
+    mocked_environment_cache.get_feature_types.return_value = None
     data = {
         "traits": [{"trait_value": "a" * 2001, "trait_key": "first_name"}],
         "identifier": "do_it_all_in_one_go_identity",
@@ -197,6 +203,7 @@ def test_get_identities(
         "edge_proxy.server.environment_service.cache"
     )
     mocked_environment_cache.get_environment.return_value = environment_1
+    mocked_environment_cache.get_feature_types.return_value = None
     mocked_environment_cache.get_identity.return_value = {
         "environment_api_key": x_environment_key,
         "identifier": identifier,
@@ -289,6 +296,7 @@ def test_get_flags__client_key__hide_disabled_flags_enabled__only_returns_enable
     mocked_environment_cache.get_environment.return_value = (
         environment_with_hide_disabled_flags
     )
+    mocked_environment_cache.get_feature_types.return_value = None
 
     # When
     response = client.get(
@@ -313,6 +321,7 @@ def test_get_flags__client_key__hide_disabled_flags_disabled__returns_all_flags(
         "edge_proxy.server.environment_service.cache"
     )
     mocked_environment_cache.get_environment.return_value = environment_1
+    mocked_environment_cache.get_feature_types.return_value = None
 
     # When
     response = client.get(
@@ -338,6 +347,7 @@ def test_get_flags__server_key__hide_disabled_flags_enabled__returns_all_flags(
     mocked_environment_cache.get_environment.return_value = (
         environment_with_hide_disabled_flags
     )
+    mocked_environment_cache.get_feature_types.return_value = None
     mocker.patch(
         "edge_proxy.server.environment_service._get_client_key_from_server_key",
         return_value=client_key,
@@ -364,6 +374,7 @@ def test_get_flags__client_key__hide_disabled_flags_enabled__single_disabled_fea
     mocked_environment_cache.get_environment.return_value = (
         environment_with_hide_disabled_flags
     )
+    mocked_environment_cache.get_feature_types.return_value = None
 
     # When
     response = client.get(
@@ -388,6 +399,7 @@ def test_post_identity__client_key__hide_disabled_flags_enabled__only_returns_en
     mocked_environment_cache.get_environment.return_value = (
         environment_with_hide_disabled_flags
     )
+    mocked_environment_cache.get_feature_types.return_value = None
     data = {
         "identifier": "test_identifier",
         "traits": [],
@@ -419,6 +431,7 @@ def test_post_identity__client_key__hide_disabled_flags_disabled__returns_all_fl
         "edge_proxy.server.environment_service.cache"
     )
     mocked_environment_cache.get_environment.return_value = environment_1
+    mocked_environment_cache.get_feature_types.return_value = None
     data = {
         "identifier": "test_identifier",
         "traits": [],


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

  - [ ] I have added information to `docs/` if required so people know about the feature!
  - [x] I have filled in the "Changes" section below?
  - [x] I have filled in the "How did you test this code" section below?
  - [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

Closes #168 

This PR upgrades the flagsmith-flag-engine from v6.1.0 to v10.0.3 following the approach from [flagsmith-python-client#150](https://github.com/Flagsmith/flagsmith-python-client/pull/150), and implements the `hide_disabled_flags` project setting.

## Changes
 ### Engine Migration (v6 → v10)
  - Upgraded `flagsmith-flag-engine` from `6.1.0` to `10.0.3`
  - Added `flagsmith>=5` dependency for TypedDict models and mappers
  - Migrated from Pydantic models to TypedDict-based evaluation contexts
  - Replaced deprecated engine functions with new `get_evaluation_result()`
  - Used `map_environment_document_to_context()` and `map_context_and_identity_data_to_context()` from flagsmith-python-client
  - Updated traits handling from `list[TraitModel]` to `dict[str, ContextValue]` with backward compatibility validator
  - Updated response mappers to work with new flag result format

  ### hide_disabled_flags
  - Added `filter_disabled_flags()` helper
  - Implemented filtering in `src/edge_proxy/environments.py` for both `/api/v1/flags/` and `/api/v1/identities/` endpoints
  - Only applies to **client keys** (server keys bypass this filter)
  - Single feature requests return **404** if the feature is disabled and `hide_disabled_flags == true`
 
  ### Tests
  - Added new tests in `tests/test_server.py` for `hide_disabled_flags` functionality
  - Added test fixture `environment_with_hide_disabled_flags` in `tests/fixtures/response_data.py`

  ## How did you test this code?
  ```

  Local Integration Testing:
  1. Start edge proxy: rye run edge-proxy-serve
  2. Test with Node.js SDK pointing to http://localhost:8000/api/v1/
  3. Verify responses with hide_disabled_flags both enabled and disabled:

  # Get all flags
  curl -s -L -H "X-Environment-Key: ser.xxx" \
    http://localhost:8000/api/v1/flags/ | jq

  # Get identity flags
  curl -s -L -X POST \
    -H "X-Environment-Key: ser.xxx" \
    -H "Content-Type: application/json" \
    -d '{"identifier": "test-user"}' \
    http://localhost:8000/api/v1/identities/ | jq
