### PR TITLE
feat: configurable timeout_keep_alive for keep-alive idle connections

### DIFF
--- a/src/edge_proxy/main.py
+++ b/src/edge_proxy/main.py
@@ -12,6 +12,7 @@ def serve():
         proxy_headers=settings.server.proxy_headers,
         reload=settings.server.reload,
         use_colors=settings.logging.colours,
+        timeout_keep_alive=settings.server.timeout_keep_alive,
     )
 
 

--- a/src/edge_proxy/settings.py
+++ b/src/edge_proxy/settings.py
@@ -106,7 +106,7 @@ class ServerSettings(BaseModel):
     # Matches uvicorn's default. Override (e.g. to 120s) when clients poll on
     # an interval longer than this — otherwise pooled connections get closed
     # server-side before the next poll, causing ConnectionResetError clients.
-    timeout_keep_alive: int = 5
+    timeout_keep_alive: int = Field(default=5, gt=0)
 
 
 class HealthCheckSettings(BaseModel):

--- a/src/edge_proxy/settings.py
+++ b/src/edge_proxy/settings.py
@@ -103,6 +103,10 @@ class ServerSettings(BaseModel):
     port: int = 8000
     reload: bool = False
     proxy_headers: bool = False
+    # Matches uvicorn's default. Override (e.g. to 120s) when clients poll on
+    # an interval longer than this — otherwise pooled connections get closed
+    # server-side before the next poll, causing ConnectionResetError clients.
+    timeout_keep_alive: int = 5
 
 
 class HealthCheckSettings(BaseModel):


### PR DESCRIPTION
## Problem

  Flagsmith SDK clients (default poll interval: 10s) intermittently see `ConnectionResetError` on the pooled `/api/v1/environment-document/` request:

  urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='10.12.40.89', port=80):
  Max retries exceeded with url: /api/v1/environment-document/
  (Caused by ProtocolError('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer')))

  ## Root cause

  uvicorn's `timeout_keep_alive` defaults to **5s**. Any HTTP intermediary in front of edge-proxy — load balancer, proxy, or the SDK's own urllib3 connection pool that holds an idle connection longer than 5s ends up reusing a half-closed socket on its next request, surfacing as connection reset. Polling SDKs are especially exposed: a 10s poll interval against a 5s server keep-alive guarantees almost every client's pooled connection is stale.

  ## Fix
  Surface `timeout_keep_alive` through edge-proxy's existing config (`config.json` / env), so operators can raise it past their client poll interval (or LB idle timeout). Default unchanged at 5s — purely additive.

## Changes
- `src/edge_proxy/settings.py`: new `timeout_keep_alive: int = 5` on `ServerSettings`
- `src/edge_proxy/main.py`: pass `timeout_keep_alive=settings.server.timeout_keep_alive` to `uvicorn.run()`

## Test plan
- [x] Unit: setting loads from config.json (\`{"server": {"timeout_keep_alive": 2}}\` → \`timeout_keep_alive=2\` on the AppConfig instance)
- [x] Integration: with \`timeout_keep_alive=2\`, server closes idle keep-alive connections at t≈2.08s 
- [x] Integration: with \`timeout_keep_alive=20\`, server closes at t≈20.09s 
- [x] Default behavior unchanged when not overridden in config